### PR TITLE
chore: generate GitHub App token in CI for Danger and publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,20 @@ commands:
                       name: Build Pigeons
                       command: dart run build_runner build --delete-conflicting-outputs
 
+  generate_luciq_github_app_token:
+    parameters:
+      script-path:
+        type: string
+        default: scripts/get-github-app-token.sh
+    steps:
+      - run:
+          name: Generate Luciq GitHub App Token
+          command: |
+            TOKEN=$(bash << parameters.script-path >> LUCIQ_APP_ID LUCIQ_PRIVATE_KEY LUCIQ_INSTALLATION_ID)
+            echo "export GH_TOKEN='$TOKEN'" >> "$BASH_ENV"
+            echo "export DANGER_GITHUB_API_TOKEN='$TOKEN'" >> "$BASH_ENV"
+            echo "export RELEASE_GITHUB_TOKEN='$TOKEN'" >> "$BASH_ENV"
+
   notify_slack_with_release:
     parameters:
       channel:
@@ -187,6 +201,7 @@ jobs:
           override-ci-command: yarn install --frozen-lockfile --network-concurrency 1
       - attach_workspace:
           at: ~/project
+      - generate_luciq_github_app_token
       - run:
           name: Run Danger
           command: yarn danger ci
@@ -485,6 +500,7 @@ jobs:
           command: |
             swift build -c release
             cp -f .build/release/Escape /usr/local/bin/escape
+      - generate_luciq_github_app_token
       - run:
           name: Publish Package
           working_directory: packages/luciq_flutter

--- a/scripts/get-github-app-token.sh
+++ b/scripts/get-github-app-token.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Generates a GitHub App installation token using openssl + curl.
+# No external dependencies required.
+#
+# Usage: bash get-github-app-token.sh <APP_ID_ENV> <PRIVATE_KEY_ENV> <INSTALLATION_ID_ENV>
+# Example: bash get-github-app-token.sh AND_LUCIQ_APP_ID AND_LUCIQ_PRIVATE_KEY AND_LUCIQ_INSTALLATION_ID
+# Example: bash get-github-app-token.sh AND_INSTABUG_APP_ID AND_INSTABUG_PRIVATE_KEY AND_INSTABUG_INSTALLATION_ID
+
+set -euo pipefail
+
+APP_ID_ENV="${1:?Usage: $0 <APP_ID_ENV> <PRIVATE_KEY_ENV> <INSTALLATION_ID_ENV>}"
+PRIVATE_KEY_ENV="${2:?Usage: $0 <APP_ID_ENV> <PRIVATE_KEY_ENV> <INSTALLATION_ID_ENV>}"
+INSTALL_ID_ENV="${3:?Usage: $0 <APP_ID_ENV> <PRIVATE_KEY_ENV> <INSTALLATION_ID_ENV>}"
+
+APP_ID="${!APP_ID_ENV:?Error: $APP_ID_ENV is not set}"
+PRIVATE_KEY="${!PRIVATE_KEY_ENV:?Error: $PRIVATE_KEY_ENV is not set}"
+INSTALL_ID="${!INSTALL_ID_ENV:?Error: $INSTALL_ID_ENV is not set}"
+
+# Reconstruct PEM file from flattened env var
+# CircleCI flattens multiline env vars into a single line,
+# so we extract header/footer and re-wrap the base64 body at 64 chars
+PEM_FILE=$(mktemp)
+chmod 600 "$PEM_FILE"
+trap 'rm -f "$PEM_FILE"' EXIT
+
+BODY=$(printf '%s' "$PRIVATE_KEY" | sed 's/-----BEGIN RSA PRIVATE KEY-----//;s/-----END RSA PRIVATE KEY-----//;s/ //g')
+{
+    echo "-----BEGIN RSA PRIVATE KEY-----"
+    echo "$BODY" | fold -w 64
+    echo "-----END RSA PRIVATE KEY-----"
+} > "$PEM_FILE"
+
+# Base64url encode (RFC 4648): replace +/ with -_, strip =
+b64url() {
+    openssl base64 -A | tr '+/' '-_' | tr -d '='
+}
+
+NOW=$(date +%s)
+IAT=$((NOW - 60))    # 60s clock skew allowance per GitHub docs
+EXP=$((NOW + 600))   # 10min max JWT lifetime per GitHub docs
+
+# Create JWT header and payload
+HEADER=$(printf '{"alg":"RS256","typ":"JWT"}' | b64url)
+PAYLOAD=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$IAT" "$EXP" "$APP_ID" | b64url)
+
+# Sign with RSA-SHA256
+SIGNATURE=$(printf '%s.%s' "$HEADER" "$PAYLOAD" | openssl dgst -sha256 -sign "$PEM_FILE" -binary | b64url)
+
+JWT_TOKEN="${HEADER}.${PAYLOAD}.${SIGNATURE}"
+
+# Exchange JWT for installation token
+RESPONSE=$(curl -sf -X POST \
+    -H "Authorization: Bearer $JWT_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/app/installations/${INSTALL_ID}/access_tokens") || {
+    echo "Error: GitHub API request failed (HTTP error)" >&2
+    exit 1
+}
+
+TOKEN=$(echo "$RESPONSE" | jq -r '.token // empty')
+
+if [ -z "$TOKEN" ]; then
+    ERROR_MSG=$(echo "$RESPONSE" | jq -r '.message // "unknown error"')
+    echo "Error: Failed to get installation token: $ERROR_MSG" >&2
+    exit 1
+fi
+
+echo "$TOKEN"


### PR DESCRIPTION
## Description of the change

Adds a reusable `generate_luciq_github_app_token` CircleCI command that runs `scripts/get-github-app-token.sh` and exports `GH_TOKEN`, `DANGER_GITHUB_API_TOKEN`, and `RELEASE_GITHUB_TOKEN` into `$BASH_ENV`. Wires it into the `danger` job (so Danger authenticates via `DANGER_GITHUB_API_TOKEN`) and before the `release_luciq_flutter` publish step (so release tooling authenticates via `RELEASE_GITHUB_TOKEN`). The token is a short-lived GitHub App installation token, replacing long-lived PATs.

The script (`scripts/get-github-app-token.sh`) generates a JWT with openssl, exchanges it for an installation token via the GitHub API, and handles CircleCI's multiline-env-var flattening by re-wrapping the PEM body at 64 chars.

Requires the following CircleCI env vars/context to be configured: `LUCIQ_APP_ID`, `LUCIQ_PRIVATE_KEY`, `LUCIQ_INSTALLATION_ID`.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
JIRA ID :

## Checklists
### Development
- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review
- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request

🤖 Generated with [Claude Code](https://claude.com/claude-code)