### PR TITLE
feat: add FeatureRequests.setEnabled

### DIFF
--- a/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/FeatureRequestsApi.java
+++ b/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/FeatureRequestsApi.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 import ai.luciq.featuresrequest.FeatureRequests;
 import ai.luciq.flutter.generated.FeatureRequestsPigeon;
 import ai.luciq.flutter.util.ArgsRegistry;
+import ai.luciq.library.Feature;
 
 import java.util.List;
 
@@ -33,5 +34,10 @@ public class FeatureRequestsApi implements FeatureRequestsPigeon.FeatureRequests
         }
 
         FeatureRequests.setEmailFieldRequired(isRequired, actions);
+    }
+
+    @Override
+    public void setEnabled(@NonNull Boolean isEnabled) {
+        FeatureRequests.setState(isEnabled ? Feature.State.ENABLED : Feature.State.DISABLED);
     }
 }

--- a/packages/luciq_flutter/android/src/test/java/ai/luciq/flutter/FeatureRequestsApiTest.java
+++ b/packages/luciq_flutter/android/src/test/java/ai/luciq/flutter/FeatureRequestsApiTest.java
@@ -10,6 +10,7 @@ import ai.luciq.featuresrequest.FeatureRequests;
 import ai.luciq.flutter.generated.FeatureRequestsPigeon;
 import ai.luciq.flutter.modules.FeatureRequestsApi;
 import ai.luciq.flutter.util.GlobalMocks;
+import ai.luciq.library.Feature;
 
 import org.junit.After;
 import org.junit.Before;
@@ -65,5 +66,19 @@ public class FeatureRequestsApiTest {
         api.setEmailFieldRequired(isRequired, actionTypes);
 
         mFeatureRequests.verify(() -> FeatureRequests.setEmailFieldRequired(isRequired, ActionType.REQUEST_NEW_FEATURE, ActionType.ADD_COMMENT_TO_FEATURE));
+    }
+
+    @Test
+    public void testSetEnabledGivenTrue() {
+        api.setEnabled(true);
+
+        mFeatureRequests.verify(() -> FeatureRequests.setState(Feature.State.ENABLED));
+    }
+
+    @Test
+    public void testSetEnabledGivenFalse() {
+        api.setEnabled(false);
+
+        mFeatureRequests.verify(() -> FeatureRequests.setState(Feature.State.DISABLED));
     }
 }

--- a/packages/luciq_flutter/ios/Classes/Modules/FeatureRequestsApi.m
+++ b/packages/luciq_flutter/ios/Classes/Modules/FeatureRequestsApi.m
@@ -23,4 +23,8 @@ extern void InitFeatureRequestsApi(id<FlutterBinaryMessenger> messenger) {
     [LCQFeatureRequests setEmailFieldRequired:[isRequired boolValue] forAction:resolvedTypes];
 }
 
+- (void)setEnabledIsEnabled:(NSNumber *)isEnabled error:(FlutterError *_Nullable *_Nonnull)error {
+    LCQFeatureRequests.enabled = [isEnabled boolValue];
+}
+
 @end

--- a/packages/luciq_flutter/lib/src/modules/feature_requests.dart
+++ b/packages/luciq_flutter/lib/src/modules/feature_requests.dart
@@ -23,6 +23,12 @@ class FeatureRequests {
     return _host.show();
   }
 
+  /// Enables or disables the Feature Requests module.
+  /// [isEnabled] A boolean that enables or disables Feature Requests.
+  static Future<void> setEnabled(bool isEnabled) async {
+    return _host.setEnabled(isEnabled);
+  }
+
   /// Sets whether users are required to enter an email address or not when sending reports.
   /// Defaults to YES.
   /// [isRequired] A boolean to indicate whether email

--- a/packages/luciq_flutter/pigeons/feature_requests.api.dart
+++ b/packages/luciq_flutter/pigeons/feature_requests.api.dart
@@ -4,4 +4,5 @@ import 'package:pigeon/pigeon.dart';
 abstract class FeatureRequestsHostApi {
   void show();
   void setEmailFieldRequired(bool isRequired, List<String> actionTypes);
+  void setEnabled(bool isEnabled);
 }

--- a/packages/luciq_flutter/test/feature_requests_test.dart
+++ b/packages/luciq_flutter/test/feature_requests_test.dart
@@ -39,4 +39,14 @@ void main() {
       mHost.setEmailFieldRequired(required, types.mapToString()),
     ).called(1);
   });
+
+  test('[setEnabled] should call host method', () async {
+    const enabled = true;
+
+    await FeatureRequests.setEnabled(enabled);
+
+    verify(
+      mHost.setEnabled(enabled),
+    ).called(1);
+  });
 }


### PR DESCRIPTION
## Summary
Adds the module-level master switch for Feature Requests, bringing Flutter closer to the React Native SDK surface.
- iOS: `LCQFeatureRequests.enabled = isEnabled`
- Android: `FeatureRequests.setState(Feature.State.ENABLED | DISABLED)`

## Test plan
- [x] `flutter test test/feature_requests_test.dart` — 3/3 pass (1 new)
- [x] `./gradlew :luciq_flutter:testDebugUnitTest --tests "ai.luciq.flutter.FeatureRequestsApiTest"` — BUILD SUCCESSFUL (2 new)
- [x] `flutter analyze` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)