### PR TITLE
feat: add BugReporting.setDidSelectPromptOptionHandler (iOS)

### DIFF
--- a/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/BugReportingApi.java
+++ b/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/BugReportingApi.java
@@ -152,6 +152,11 @@ public class BugReportingApi implements BugReportingPigeon.BugReportingHostApi {
     }
 
     @Override
+    public void bindOnDidSelectPromptOptionCallback() {
+        // iOS Only
+    }
+
+    @Override
     public void bindOnDismissCallback() {
         BugReporting.setOnDismissCallback(new OnSdkDismissCallback() {
             @Override

--- a/packages/luciq_flutter/android/src/test/java/ai/luciq/flutter/BugReportingApiTest.java
+++ b/packages/luciq_flutter/android/src/test/java/ai/luciq/flutter/BugReportingApiTest.java
@@ -177,6 +177,13 @@ public class BugReportingApiTest {
     }
 
     @Test
+    public void testBindOnDidSelectPromptOptionCallbackIsNoOpOnAndroid() {
+        api.bindOnDidSelectPromptOptionCallback();
+
+        mBugReporting.verifyNoInteractions();
+    }
+
+    @Test
     public void testSetDisclaimerText() {
         String text = "My very own disclaimer text";
 

--- a/packages/luciq_flutter/example/lib/main.dart
+++ b/packages/luciq_flutter/example/lib/main.dart
@@ -58,6 +58,11 @@ void main() {
         appVariant: 'variant 1',
       );
 
+      BugReporting.setDidSelectPromptOptionIOSHandler((promptOption) {
+
+        print('promptOption: $promptOption');
+
+      },);
       Luciq.setValueForStringWithKey('text you want',
           CustomTextPlaceHolderKey.commentFieldHintForBugReport);
 

--- a/packages/luciq_flutter/ios/Classes/Modules/BugReportingApi.m
+++ b/packages/luciq_flutter/ios/Classes/Modules/BugReportingApi.m
@@ -127,6 +127,8 @@ extern void InitBugReportingApi(id<FlutterBinaryMessenger> messenger) {
         } else if (promptOption == LCQPromptOptionChat) {
             promptOptionString = @"chat";
         } else {
+            // Maps both LCQPromptOptionNone (user closed prompt) and any
+            // future, unrecognized LCQPromptOption value to "none".
             promptOptionString = @"none";
         }
         [self->_flutterApi onDidSelectPromptOptionPromptOption:promptOptionString

--- a/packages/luciq_flutter/ios/Classes/Modules/BugReportingApi.m
+++ b/packages/luciq_flutter/ios/Classes/Modules/BugReportingApi.m
@@ -117,6 +117,24 @@ extern void InitBugReportingApi(id<FlutterBinaryMessenger> messenger) {
     };
 }
 
+- (void)bindOnDidSelectPromptOptionCallbackWithError:(FlutterError *_Nullable *_Nonnull)error {
+    LCQBugReporting.didSelectPromptOptionHandler = ^(LCQPromptOption promptOption) {
+        NSString *promptOptionString;
+        if (promptOption == LCQPromptOptionBug) {
+            promptOptionString = @"bug";
+        } else if (promptOption == LCQPromptOptionFeedback) {
+            promptOptionString = @"feedback";
+        } else if (promptOption == LCQPromptOptionChat) {
+            promptOptionString = @"chat";
+        } else {
+            promptOptionString = @"none";
+        }
+        [self->_flutterApi onDidSelectPromptOptionPromptOption:promptOptionString
+                                                    completion:^(FlutterError *_Nullable _){
+                                                    }];
+    };
+}
+
 - (void)bindOnDismissCallbackWithError:(FlutterError *_Nullable *_Nonnull)error {
     LCQBugReporting.didDismissHandler = ^(LCQDismissType dismissType, LCQReportCategory reportType) {
       // Parse dismiss type enum

--- a/packages/luciq_flutter/lib/src/modules/bug_reporting.dart
+++ b/packages/luciq_flutter/lib/src/modules/bug_reporting.dart
@@ -26,6 +26,8 @@ enum DismissType { cancel, submit, addAttachment }
 
 enum ReportType { bug, feedback, question, other }
 
+enum PromptOption { bug, feedback, chat, none }
+
 enum ExtendedBugReportMode {
   enabledWithRequiredFields,
   enabledWithOptionalFields,
@@ -43,7 +45,9 @@ enum Position {
 
 typedef OnSDKInvokeCallback = void Function();
 typedef OnSDKDismissCallback = void Function(DismissType, ReportType);
-typedef OnDidSelectPromptOptionCallback = void Function(String promptOption);
+typedef OnDidSelectPromptOptionCallback = void Function(
+  PromptOption promptOption,
+);
 
 class BugReporting implements BugReportingFlutterApi {
   static var _host = BugReportingHostApi();
@@ -77,7 +81,17 @@ class BugReporting implements BugReportingFlutterApi {
   @internal
   @override
   void onDidSelectPromptOption(String promptOption) {
-    _onDidSelectPromptOptionCallback?.call(promptOption);
+    const promptOptionMapper = {
+      'bug': PromptOption.bug,
+      'feedback': PromptOption.feedback,
+      'chat': PromptOption.chat,
+      'none': PromptOption.none,
+    };
+
+    final mapped = promptOptionMapper[promptOption];
+    if (mapped != null) {
+      _onDidSelectPromptOptionCallback?.call(mapped);
+    }
   }
 
   /// @nodoc
@@ -136,10 +150,9 @@ class BugReporting implements BugReportingFlutterApi {
     return _host.bindOnDismissCallback();
   }
 
+  /// iOS Only
   /// Sets a block of code to be executed when a prompt option is selected.
-  /// The [callback] receives the selected prompt option as a string
-  /// (`'bug'`, `'feedback'`, `'chat'`, or `'none'`).
-  /// @iOS ONLY
+  /// The [callback] receives the selected [PromptOption].
   static Future<void> setDidSelectPromptOptionHandler(
     OnDidSelectPromptOptionCallback callback,
   ) async {

--- a/packages/luciq_flutter/lib/src/modules/bug_reporting.dart
+++ b/packages/luciq_flutter/lib/src/modules/bug_reporting.dart
@@ -43,6 +43,7 @@ enum Position {
 
 typedef OnSDKInvokeCallback = void Function();
 typedef OnSDKDismissCallback = void Function(DismissType, ReportType);
+typedef OnDidSelectPromptOptionCallback = void Function(String promptOption);
 
 class BugReporting implements BugReportingFlutterApi {
   static var _host = BugReportingHostApi();
@@ -50,6 +51,7 @@ class BugReporting implements BugReportingFlutterApi {
 
   static OnSDKInvokeCallback? _onInvokeCallback;
   static OnSDKDismissCallback? _onDismissCallback;
+  static OnDidSelectPromptOptionCallback? _onDidSelectPromptOptionCallback;
 
   /// @nodoc
   @visibleForTesting
@@ -69,6 +71,13 @@ class BugReporting implements BugReportingFlutterApi {
   @override
   void onSdkInvoke() {
     _onInvokeCallback?.call();
+  }
+
+  /// @nodoc
+  @internal
+  @override
+  void onDidSelectPromptOption(String promptOption) {
+    _onDidSelectPromptOptionCallback?.call(promptOption);
   }
 
   /// @nodoc
@@ -125,6 +134,19 @@ class BugReporting implements BugReportingFlutterApi {
   ) async {
     _onDismissCallback = callback;
     return _host.bindOnDismissCallback();
+  }
+
+  /// Sets a block of code to be executed when a prompt option is selected.
+  /// The [callback] receives the selected prompt option as a string
+  /// (`'bug'`, `'feedback'`, `'chat'`, or `'none'`).
+  /// @iOS ONLY
+  static Future<void> setDidSelectPromptOptionHandler(
+    OnDidSelectPromptOptionCallback callback,
+  ) async {
+    if (LCQBuildInfo.instance.isIOS) {
+      _onDidSelectPromptOptionCallback = callback;
+      return _host.bindOnDidSelectPromptOptionCallback();
+    }
   }
 
   /// Sets the events that invoke the feedback form.

--- a/packages/luciq_flutter/lib/src/modules/bug_reporting.dart
+++ b/packages/luciq_flutter/lib/src/modules/bug_reporting.dart
@@ -153,7 +153,7 @@ class BugReporting implements BugReportingFlutterApi {
   /// iOS Only
   /// Sets a block of code to be executed when a prompt option is selected.
   /// The [callback] receives the selected [PromptOption].
-  static Future<void> setDidSelectPromptOptionHandler(
+  static Future<void> setDidSelectPromptOptionIOSHandler(
     OnDidSelectPromptOptionCallback callback,
   ) async {
     if (LCQBuildInfo.instance.isIOS) {

--- a/packages/luciq_flutter/pigeons/bug_reporting.api.dart
+++ b/packages/luciq_flutter/pigeons/bug_reporting.api.dart
@@ -4,6 +4,7 @@ import 'package:pigeon/pigeon.dart';
 abstract class BugReportingFlutterApi {
   void onSdkInvoke();
   void onSdkDismiss(String dismissType, String reportType);
+  void onDidSelectPromptOption(String promptOption);
 }
 
 @HostApi()
@@ -27,6 +28,7 @@ abstract class BugReportingHostApi {
   );
   void bindOnInvokeCallback();
   void bindOnDismissCallback();
+  void bindOnDidSelectPromptOptionCallback();
   void setDisclaimerText(String text);
   void setCommentMinimumCharacterCount(
     int limit,

--- a/packages/luciq_flutter/test/bug_reporting_test.dart
+++ b/packages/luciq_flutter/test/bug_reporting_test.dart
@@ -210,4 +210,32 @@ void main() {
 
     verify(mHost.setProactiveReportingConfigurations(true, 1, 1)).called(1);
   });
+
+  test(
+    '[setDidSelectPromptOptionHandler] should call host method on iOS and invoke callback',
+    () async {
+      when(mBuildInfo.isIOS).thenReturn(true);
+      String? received;
+
+      await BugReporting.setDidSelectPromptOptionHandler((promptOption) {
+        received = promptOption;
+      });
+
+      verify(mHost.bindOnDidSelectPromptOptionCallback()).called(1);
+
+      BugReporting().onDidSelectPromptOption('bug');
+      expect(received, 'bug');
+    },
+  );
+
+  test(
+    '[setDidSelectPromptOptionHandler] should not call host method on Android',
+    () async {
+      when(mBuildInfo.isIOS).thenReturn(false);
+
+      await BugReporting.setDidSelectPromptOptionHandler((_) {});
+
+      verifyNever(mHost.bindOnDidSelectPromptOptionCallback());
+    },
+  );
 }

--- a/packages/luciq_flutter/test/bug_reporting_test.dart
+++ b/packages/luciq_flutter/test/bug_reporting_test.dart
@@ -212,12 +212,12 @@ void main() {
   });
 
   test(
-    '[setDidSelectPromptOptionHandler] should call host method on iOS, map every value, and ignore unknown values',
+    '[setDidSelectPromptOptionIOSHandler] should call host method on iOS, map every value, and ignore unknown values',
     () async {
       when(mBuildInfo.isIOS).thenReturn(true);
       PromptOption? received;
 
-      await BugReporting.setDidSelectPromptOptionHandler((promptOption) {
+      await BugReporting.setDidSelectPromptOptionIOSHandler((promptOption) {
         received = promptOption;
       });
 
@@ -243,11 +243,11 @@ void main() {
   );
 
   test(
-    '[setDidSelectPromptOptionHandler] should not call host method on Android',
+    '[setDidSelectPromptOptionIOSHandler] should not call host method on Android',
     () async {
       when(mBuildInfo.isIOS).thenReturn(false);
 
-      await BugReporting.setDidSelectPromptOptionHandler((_) {});
+      await BugReporting.setDidSelectPromptOptionIOSHandler((_) {});
 
       verifyNever(mHost.bindOnDidSelectPromptOptionCallback());
     },

--- a/packages/luciq_flutter/test/bug_reporting_test.dart
+++ b/packages/luciq_flutter/test/bug_reporting_test.dart
@@ -212,10 +212,10 @@ void main() {
   });
 
   test(
-    '[setDidSelectPromptOptionHandler] should call host method on iOS and invoke callback',
+    '[setDidSelectPromptOptionHandler] should call host method on iOS, map every value, and ignore unknown values',
     () async {
       when(mBuildInfo.isIOS).thenReturn(true);
-      String? received;
+      PromptOption? received;
 
       await BugReporting.setDidSelectPromptOptionHandler((promptOption) {
         received = promptOption;
@@ -223,8 +223,22 @@ void main() {
 
       verify(mHost.bindOnDidSelectPromptOptionCallback()).called(1);
 
-      BugReporting().onDidSelectPromptOption('bug');
-      expect(received, 'bug');
+      const cases = {
+        'bug': PromptOption.bug,
+        'feedback': PromptOption.feedback,
+        'chat': PromptOption.chat,
+        'none': PromptOption.none,
+      };
+
+      cases.forEach((raw, expected) {
+        received = null;
+        BugReporting().onDidSelectPromptOption(raw);
+        expect(received, expected, reason: 'failed for "$raw"');
+      });
+
+      received = null;
+      BugReporting().onDidSelectPromptOption('unknown');
+      expect(received, isNull);
     },
   );
 


### PR DESCRIPTION
## Summary
Adds an iOS callback invoked when the user selects a prompt option in the invocation UI. Receives the selected option as one of `"bug"`, `"feedback"`, `"chat"`, or `"none"`, matching the native `LCQPromptOption` enum.

- iOS: installs `LCQBugReporting.didSelectPromptOptionHandler` and bridges to Dart via a new pigeon `FlutterApi.onDidSelectPromptOption`.
- Android: no-op (matches RN, which also no-ops on Android).

## API
```dart
BugReporting.setDidSelectPromptOptionHandler((promptOption) {
  // promptOption is one of: 'bug', 'feedback', 'chat', 'none'
});
```

## Test plan
- [x] `flutter test test/bug_reporting_test.dart` — 19/19 pass (2 new)
- [x] `./gradlew :luciq_flutter:testDebugUnitTest --tests "ai.luciq.flutter.BugReportingApiTest"` — BUILD SUCCESSFUL (1 new)
- [x] `flutter analyze` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)