### PR TITLE
feat: add SessionReplay.setSyncCallback with SessionMetadata model

### DIFF
--- a/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/SessionReplayApi.java
+++ b/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/SessionReplayApi.java
@@ -83,9 +83,6 @@ public class SessionReplayApi implements SessionReplayPigeon.SessionReplayHostAp
 
     @Override
     public void bindOnSyncCallback() {
-        ThreadManager.runOnMainThread(new Runnable() {
-            @Override
-            public void run() {
                 SessionReplay.setSyncCallback(new SessionSyncListener() {
                     @Override
                     public boolean onSessionReadyToSync(@NonNull SessionMetadata metadata) {
@@ -94,13 +91,18 @@ public class SessionReplayApi implements SessionReplayPigeon.SessionReplayHostAp
                         // Pigeon FlutterApi messages are delivered on the main (platform) thread.
                         // The SDK invokes this sync listener on a background thread, so
                         // awaiting the latch here does not block the Flutter bridge.
-                        flutterApi.onShouldSyncSession(
-                                serializeMetadata(metadata),
-                                new SessionReplayPigeon.SessionReplayFlutterApi.Reply<Void>() {
-                                    @Override
-                                    public void reply(Void reply) {
-                                    }
-                                });
+
+                        ThreadManager.runOnMainThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                flutterApi.onShouldSyncSession(
+                                        serializeMetadata(metadata),
+                                        new SessionReplayPigeon.SessionReplayFlutterApi.Reply<Void>() {
+                                            @Override
+                                            public void reply(Void reply) {
+                                            }
+                                        });
+                            }});
 
                         try {
                             latch.await();
@@ -112,8 +114,8 @@ public class SessionReplayApi implements SessionReplayPigeon.SessionReplayHostAp
                     }
                 });
             }
-        });
-    }
+
+
 
     @Override
     public void evaluateSync(@NonNull Boolean result) {

--- a/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/SessionReplayApi.java
+++ b/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/SessionReplayApi.java
@@ -4,14 +4,35 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import ai.luciq.flutter.generated.SessionReplayPigeon;
 import ai.luciq.flutter.util.ArgsRegistry;
+import ai.luciq.flutter.util.ThreadManager;
+import ai.luciq.library.SessionSyncListener;
 import ai.luciq.library.sessionreplay.SessionReplay;
+import ai.luciq.library.sessionreplay.model.SessionMetadata;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
 import io.flutter.plugin.common.BinaryMessenger;
 
 public class SessionReplayApi implements SessionReplayPigeon.SessionReplayHostApi {
 
+    private final SessionReplayPigeon.SessionReplayFlutterApi flutterApi;
+
+    private boolean shouldSync = true;
+    private CountDownLatch latch;
+
     public static void init(BinaryMessenger messenger) {
-        final SessionReplayApi api = new SessionReplayApi();
+        final SessionReplayPigeon.SessionReplayFlutterApi flutterApi =
+                new SessionReplayPigeon.SessionReplayFlutterApi(messenger);
+        final SessionReplayApi api = new SessionReplayApi(flutterApi);
         SessionReplayPigeon.SessionReplayHostApi.setup(messenger, api);
+    }
+
+    public SessionReplayApi(SessionReplayPigeon.SessionReplayFlutterApi flutterApi) {
+        this.flutterApi = flutterApi;
     }
 
     @Override
@@ -60,4 +81,73 @@ public class SessionReplayApi implements SessionReplayPigeon.SessionReplayHostAp
         SessionReplay.setScreenshotQuality(quality);
     }
 
+    @Override
+    public void bindOnSyncCallback() {
+        ThreadManager.runOnMainThread(new Runnable() {
+            @Override
+            public void run() {
+                SessionReplay.setSyncCallback(new SessionSyncListener() {
+                    @Override
+                    public boolean onSessionReadyToSync(@NonNull SessionMetadata metadata) {
+                        latch = new CountDownLatch(1);
+
+                        // Pigeon FlutterApi messages are delivered on the main (platform) thread.
+                        // The SDK invokes this sync listener on a background thread, so
+                        // awaiting the latch here does not block the Flutter bridge.
+                        flutterApi.onShouldSyncSession(
+                                serializeMetadata(metadata),
+                                new SessionReplayPigeon.SessionReplayFlutterApi.Reply<Void>() {
+                                    @Override
+                                    public void reply(Void reply) {
+                                    }
+                                });
+
+                        try {
+                            latch.await();
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                            return true;
+                        }
+                        return shouldSync;
+                    }
+                });
+            }
+        });
+    }
+
+    @Override
+    public void evaluateSync(@NonNull Boolean result) {
+        shouldSync = result;
+        if (latch != null) {
+            latch.countDown();
+        }
+    }
+
+    private Map<String, Object> serializeMetadata(SessionMetadata metadata) {
+        final Map<String, Object> map = new HashMap<>();
+        map.put("appVersion", metadata.getAppVersion());
+        map.put("os", metadata.getOs());
+        map.put("device", metadata.getDevice());
+        map.put("sessionDurationInSeconds", metadata.getSessionDurationInSeconds());
+        map.put("hasLinkToAppReview", metadata.getLinkedToReview());
+        map.put("launchType", metadata.getLaunchType());
+        map.put("launchDuration", metadata.getLaunchDuration());
+        map.put("bugsCount", 0L);
+        map.put("fatalCrashCount", 0L);
+        map.put("oomCrashCount", 0L);
+
+        final List<Map<String, Object>> logs = new ArrayList<>();
+        if (metadata.getNetworkLogs() != null) {
+            for (SessionMetadata.NetworkLog log : metadata.getNetworkLogs()) {
+                final Map<String, Object> logMap = new HashMap<>();
+                logMap.put("url", log.getUrl());
+                logMap.put("duration", log.getDuration());
+                logMap.put("statusCode", (long) log.getStatusCode());
+                logs.add(logMap);
+            }
+        }
+        map.put("networkLogs", logs);
+
+        return map;
+    }
 }

--- a/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/SessionReplayApi.java
+++ b/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/SessionReplayApi.java
@@ -13,16 +13,24 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import io.flutter.plugin.common.BinaryMessenger;
 
 public class SessionReplayApi implements SessionReplayPigeon.SessionReplayHostApi {
 
+    static final long SYNC_CALLBACK_TIMEOUT_SECONDS = 5L;
+
     private final SessionReplayPigeon.SessionReplayFlutterApi flutterApi;
 
-    private volatile boolean shouldSync = true;
-    private volatile CountDownLatch latch;
+    private final ConcurrentLinkedDeque<PendingSync> pendingSyncs = new ConcurrentLinkedDeque<>();
+
+    private static final class PendingSync {
+        final CountDownLatch latch = new CountDownLatch(1);
+        volatile boolean shouldSync = true;
+    }
 
     public static void init(BinaryMessenger messenger) {
         final SessionReplayPigeon.SessionReplayFlutterApi flutterApi =
@@ -83,45 +91,51 @@ public class SessionReplayApi implements SessionReplayPigeon.SessionReplayHostAp
 
     @Override
     public void bindOnSyncCallback() {
-                SessionReplay.setSyncCallback(new SessionSyncListener() {
+        SessionReplay.setSyncCallback(new SessionSyncListener() {
+            @Override
+            public boolean onSessionReadyToSync(@NonNull SessionMetadata metadata) {
+                final PendingSync sync = new PendingSync();
+                pendingSyncs.addLast(sync);
+
+                // Pigeon FlutterApi messages are delivered on the main (platform) thread.
+                // The SDK invokes this sync listener on a background thread, so awaiting
+                // the latch here does not block the Flutter bridge.
+                ThreadManager.runOnMainThread(new Runnable() {
                     @Override
-                    public boolean onSessionReadyToSync(@NonNull SessionMetadata metadata) {
-                        latch = new CountDownLatch(1);
-
-                        // Pigeon FlutterApi messages are delivered on the main (platform) thread.
-                        // The SDK invokes this sync listener on a background thread, so
-                        // awaiting the latch here does not block the Flutter bridge.
-
-                        ThreadManager.runOnMainThread(new Runnable() {
-                            @Override
-                            public void run() {
-                                flutterApi.onShouldSyncSession(
-                                        serializeMetadata(metadata),
-                                        new SessionReplayPigeon.SessionReplayFlutterApi.Reply<Void>() {
-                                            @Override
-                                            public void reply(Void reply) {
-                                            }
-                                        });
-                            }});
-
-                        try {
-                            latch.await();
-                        } catch (InterruptedException e) {
-                            e.printStackTrace();
-                            return true;
-                        }
-                        return shouldSync;
+                    public void run() {
+                        flutterApi.onShouldSyncSession(
+                                serializeMetadata(metadata),
+                                new SessionReplayPigeon.SessionReplayFlutterApi.Reply<Void>() {
+                                    @Override
+                                    public void reply(Void reply) {
+                                    }
+                                });
                     }
                 });
+
+                try {
+                    if (!sync.latch.await(SYNC_CALLBACK_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                        // Flutter isolate did not respond in time — drop the pending entry
+                        // and fall back to syncing rather than wedging the SDK thread.
+                        pendingSyncs.remove(sync);
+                        return true;
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    pendingSyncs.remove(sync);
+                    return true;
+                }
+                return sync.shouldSync;
             }
-
-
+        });
+    }
 
     @Override
     public void evaluateSync(@NonNull Boolean result) {
-        shouldSync = result;
-        if (latch != null) {
-            latch.countDown();
+        final PendingSync sync = pendingSyncs.pollFirst();
+        if (sync != null) {
+            sync.shouldSync = result;
+            sync.latch.countDown();
         }
     }
 

--- a/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/SessionReplayApi.java
+++ b/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/SessionReplayApi.java
@@ -21,8 +21,8 @@ public class SessionReplayApi implements SessionReplayPigeon.SessionReplayHostAp
 
     private final SessionReplayPigeon.SessionReplayFlutterApi flutterApi;
 
-    private boolean shouldSync = true;
-    private CountDownLatch latch;
+    private volatile boolean shouldSync = true;
+    private volatile CountDownLatch latch;
 
     public static void init(BinaryMessenger messenger) {
         final SessionReplayPigeon.SessionReplayFlutterApi flutterApi =

--- a/packages/luciq_flutter/android/src/test/java/ai/luciq/flutter/SessionReplayApiTest.java
+++ b/packages/luciq_flutter/android/src/test/java/ai/luciq/flutter/SessionReplayApiTest.java
@@ -4,15 +4,22 @@ import ai.luciq.flutter.generated.SessionReplayPigeon;
 import ai.luciq.flutter.modules.SessionReplayApi;
 import ai.luciq.flutter.util.GlobalMocks;
 import ai.luciq.library.OnSessionReplayLinkReady;
+import ai.luciq.library.SessionSyncListener;
 import ai.luciq.library.sessionreplay.CapturingMode;
 import ai.luciq.library.sessionreplay.ScreenshotQuality;
 import ai.luciq.library.sessionreplay.SessionReplay;
+import ai.luciq.library.sessionreplay.model.SessionMetadata;
 import io.flutter.plugin.common.BinaryMessenger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -22,7 +29,10 @@ import static org.mockito.Mockito.verify;
 
 
 public class SessionReplayApiTest {
-    private final SessionReplayApi api = new SessionReplayApi();
+    private final BinaryMessenger mMessenger = mock(BinaryMessenger.class);
+    private final SessionReplayPigeon.SessionReplayFlutterApi flutterApi =
+            new SessionReplayPigeon.SessionReplayFlutterApi(mMessenger);
+    private final SessionReplayApi api = new SessionReplayApi(flutterApi);
     private MockedStatic<SessionReplay> mSessionReplay;
     private MockedStatic<SessionReplayPigeon.SessionReplayHostApi> mHostApi;
 
@@ -163,5 +173,66 @@ public class SessionReplayApiTest {
         mSessionReplay.verify(() -> SessionReplay.setScreenshotQuality(ScreenshotQuality.GREYSCALE));
     }
 
+    @Test
+    public void testBindOnSyncCallbackInstallsListener() {
+        api.bindOnSyncCallback();
+
+        mSessionReplay.verify(() -> SessionReplay.setSyncCallback(any(SessionSyncListener.class)));
+    }
+
+    @Test
+    public void testEvaluateSyncReturnsValueToListener() throws InterruptedException {
+        final SessionMetadata metadata = new SessionMetadata.Builder(
+                "iPhone15,2", "iOS 17.0", "1.2.3", 42L, true,
+                "Cold", 1500L, Collections.emptyList()
+        ).build();
+
+        final ArgumentCaptor<SessionSyncListener> listenerCaptor =
+                ArgumentCaptor.forClass(SessionSyncListener.class);
+        api.bindOnSyncCallback();
+        mSessionReplay.verify(() -> SessionReplay.setSyncCallback(listenerCaptor.capture()));
+        final SessionSyncListener listener = listenerCaptor.getValue();
+
+        final boolean[] result = new boolean[1];
+        final Thread listenerThread = new Thread(() -> {
+            result[0] = listener.onSessionReadyToSync(metadata);
+        });
+        listenerThread.start();
+
+        // Give the listener time to reach latch.await()
+        Thread.sleep(100);
+
+        api.evaluateSync(false);
+        listenerThread.join(1000);
+
+        assertFalse("listener should return evaluateSync's value", result[0]);
+    }
+
+    @Test
+    public void testEvaluateSyncTrue() throws InterruptedException {
+        final SessionMetadata metadata = new SessionMetadata.Builder(
+                "pixel", "Android 13", "1.0.0", 10L, false,
+                null, null, Collections.emptyList()
+        ).build();
+
+        final ArgumentCaptor<SessionSyncListener> listenerCaptor =
+                ArgumentCaptor.forClass(SessionSyncListener.class);
+        api.bindOnSyncCallback();
+        mSessionReplay.verify(() -> SessionReplay.setSyncCallback(listenerCaptor.capture()));
+        final SessionSyncListener listener = listenerCaptor.getValue();
+
+        final boolean[] result = new boolean[1];
+        final Thread listenerThread = new Thread(() -> {
+            result[0] = listener.onSessionReadyToSync(metadata);
+        });
+        listenerThread.start();
+
+        Thread.sleep(100);
+
+        api.evaluateSync(true);
+        listenerThread.join(1000);
+
+        assertTrue(result[0]);
+    }
 }
 

--- a/packages/luciq_flutter/android/src/test/java/ai/luciq/flutter/SessionReplayApiTest.java
+++ b/packages/luciq_flutter/android/src/test/java/ai/luciq/flutter/SessionReplayApiTest.java
@@ -193,19 +193,19 @@ public class SessionReplayApiTest {
         mSessionReplay.verify(() -> SessionReplay.setSyncCallback(listenerCaptor.capture()));
         final SessionSyncListener listener = listenerCaptor.getValue();
 
-        final boolean[] result = new boolean[1];
-        final Thread listenerThread = new Thread(() -> {
-            result[0] = listener.onSessionReadyToSync(metadata);
+        // Run the listener on this test thread so Mockito's thread-local static mock
+        // for ThreadManager applies. evaluateSync must come from a different thread
+        // so it can countDown the latch the listener awaits.
+        final Thread evaluator = new Thread(() -> {
+            try { Thread.sleep(100); } catch (InterruptedException ignored) {}
+            api.evaluateSync(false);
         });
-        listenerThread.start();
+        evaluator.start();
 
-        // Give the listener time to reach latch.await()
-        Thread.sleep(100);
+        boolean result = listener.onSessionReadyToSync(metadata);
+        evaluator.join(1000);
 
-        api.evaluateSync(false);
-        listenerThread.join(1000);
-
-        assertFalse("listener should return evaluateSync's value", result[0]);
+        assertFalse("listener should return evaluateSync's value", result);
     }
 
     @Test
@@ -221,18 +221,16 @@ public class SessionReplayApiTest {
         mSessionReplay.verify(() -> SessionReplay.setSyncCallback(listenerCaptor.capture()));
         final SessionSyncListener listener = listenerCaptor.getValue();
 
-        final boolean[] result = new boolean[1];
-        final Thread listenerThread = new Thread(() -> {
-            result[0] = listener.onSessionReadyToSync(metadata);
+        final Thread evaluator = new Thread(() -> {
+            try { Thread.sleep(100); } catch (InterruptedException ignored) {}
+            api.evaluateSync(true);
         });
-        listenerThread.start();
+        evaluator.start();
 
-        Thread.sleep(100);
+        boolean result = listener.onSessionReadyToSync(metadata);
+        evaluator.join(1000);
 
-        api.evaluateSync(true);
-        listenerThread.join(1000);
-
-        assertTrue(result[0]);
+        assertTrue(result);
     }
 }
 

--- a/packages/luciq_flutter/android/src/test/java/ai/luciq/flutter/SessionReplayApiTest.java
+++ b/packages/luciq_flutter/android/src/test/java/ai/luciq/flutter/SessionReplayApiTest.java
@@ -232,5 +232,45 @@ public class SessionReplayApiTest {
 
         assertTrue(result);
     }
-}
 
+    @Test
+    public void testListenerCanBeReinvokedAfterEvaluation() throws InterruptedException {
+        // A second listener invocation after the first has been resolved must not
+        // reuse the already-counted-down latch. Each invocation creates a fresh
+        // PendingSync; this test guards against regressing to a single shared slot.
+        final SessionMetadata metadata = new SessionMetadata.Builder(
+                "pixel", "Android 13", "1.0.0", 10L, false,
+                "Cold", null, Collections.emptyList()
+        ).build();
+
+        final ArgumentCaptor<SessionSyncListener> listenerCaptor =
+                ArgumentCaptor.forClass(SessionSyncListener.class);
+        api.bindOnSyncCallback();
+        mSessionReplay.verify(() -> SessionReplay.setSyncCallback(listenerCaptor.capture()));
+        final SessionSyncListener listener = listenerCaptor.getValue();
+
+        final Thread evaluator1 = new Thread(() -> {
+            try { Thread.sleep(50); } catch (InterruptedException ignored) {}
+            api.evaluateSync(false);
+        });
+        evaluator1.start();
+        final boolean firstResult = listener.onSessionReadyToSync(metadata);
+        evaluator1.join(1000);
+        assertFalse("first invocation should reflect first evaluateSync", firstResult);
+
+        final Thread evaluator2 = new Thread(() -> {
+            try { Thread.sleep(50); } catch (InterruptedException ignored) {}
+            api.evaluateSync(true);
+        });
+        evaluator2.start();
+        final boolean secondResult = listener.onSessionReadyToSync(metadata);
+        evaluator2.join(1000);
+        assertTrue("second invocation should reflect second evaluateSync", secondResult);
+    }
+
+    @Test
+    public void testEvaluateSyncBeforeBindIsNoOp() {
+        api.evaluateSync(false);
+        api.evaluateSync(true);
+    }
+}

--- a/packages/luciq_flutter/example/ios/LuciqTests/SessionReplayApiTests.m
+++ b/packages/luciq_flutter/example/ios/LuciqTests/SessionReplayApiTests.m
@@ -125,5 +125,36 @@
     OCMVerify([self.mSessionReplay setScreenshotQualityMode:LCQScreenshotQualityModeGreyScale]);
 }
 
+- (void)testEvaluateSyncResolvesPendingCompletionsInFifoOrder {
+    // Two pending completions are queued (mirrors two concurrent invocations of the
+    // sync listener). Each evaluateSync call must resolve exactly one pending entry
+    // in FIFO order — not overwrite a single shared slot.
+    XCTestExpectation *firstCalled = [self expectationWithDescription:@"first completion called with NO"];
+    XCTestExpectation *secondCalled = [self expectationWithDescription:@"second completion called with YES"];
+
+    self.api.pendingSessionEvaluationCompletions = [NSMutableArray array];
+    [self.api.pendingSessionEvaluationCompletions addObject:[^(BOOL value) {
+        XCTAssertFalse(value);
+        [firstCalled fulfill];
+    } copy]];
+    [self.api.pendingSessionEvaluationCompletions addObject:[^(BOOL value) {
+        XCTAssertTrue(value);
+        [secondCalled fulfill];
+    } copy]];
+
+    FlutterError *error;
+    [self.api evaluateSyncResult:@NO error:&error];
+    [self.api evaluateSyncResult:@YES error:&error];
+
+    [self waitForExpectations:@[firstCalled, secondCalled] timeout:1.0 enforceOrder:YES];
+    XCTAssertEqual(self.api.pendingSessionEvaluationCompletions.count, 0);
+}
+
+- (void)testEvaluateSyncBeforeBindIsNoOp {
+    // Calling evaluateSync with no pending completion must not crash.
+    self.api.pendingSessionEvaluationCompletions = [NSMutableArray array];
+    FlutterError *error;
+    [self.api evaluateSyncResult:@YES error:&error];
+}
 
 @end

--- a/packages/luciq_flutter/example/lib/main.dart
+++ b/packages/luciq_flutter/example/lib/main.dart
@@ -51,6 +51,10 @@ void main() {
     () {
       WidgetsFlutterBinding.ensureInitialized();
 
+      SessionReplay.setSyncCallback((session){
+        print(session);
+        return true;
+      });
       Luciq.init(
         token: '0174a800719ebdebf7b248fa6ae2ef17',
         invocationEvents: [InvocationEvent.floatingButton],

--- a/packages/luciq_flutter/ios/Classes/Modules/SessionReplayApi.h
+++ b/packages/luciq_flutter/ios/Classes/Modules/SessionReplayApi.h
@@ -5,7 +5,7 @@ extern void InitSessionReplayApi(id<FlutterBinaryMessenger> messenger);
 @interface SessionReplayApi : NSObject <SessionReplayHostApi>
 
 @property(nonatomic, strong) SessionReplayFlutterApi *flutterApi;
-@property(nonatomic, copy, nullable) void (^pendingSessionEvaluationCompletion)(BOOL);
+@property(nonatomic, strong) NSMutableArray<void (^)(BOOL)> *pendingSessionEvaluationCompletions;
 
 - (instancetype)initWithFlutterApi:(SessionReplayFlutterApi *)api;
 

--- a/packages/luciq_flutter/ios/Classes/Modules/SessionReplayApi.h
+++ b/packages/luciq_flutter/ios/Classes/Modules/SessionReplayApi.h
@@ -3,4 +3,10 @@
 extern void InitSessionReplayApi(id<FlutterBinaryMessenger> messenger);
 
 @interface SessionReplayApi : NSObject <SessionReplayHostApi>
+
+@property(nonatomic, strong) SessionReplayFlutterApi *flutterApi;
+@property(nonatomic, copy, nullable) void (^pendingSessionEvaluationCompletion)(BOOL);
+
+- (instancetype)initWithFlutterApi:(SessionReplayFlutterApi *)api;
+
 @end

--- a/packages/luciq_flutter/ios/Classes/Modules/SessionReplayApi.m
+++ b/packages/luciq_flutter/ios/Classes/Modules/SessionReplayApi.m
@@ -1,15 +1,23 @@
 #import <Flutter/Flutter.h>
 #import <LuciqSDK/LuciqSDK.h>
 #import <LuciqSDK/LCQSessionReplay.h>
+#import <LuciqSDK/LCQSessionMetadata.h>
 #import "SessionReplayApi.h"
 #import "ArgsRegistry.h"
 
 extern void InitSessionReplayApi(id<FlutterBinaryMessenger> messenger) {
-    SessionReplayApi *api = [[SessionReplayApi alloc] init];
+    SessionReplayFlutterApi *flutterApi = [[SessionReplayFlutterApi alloc] initWithBinaryMessenger:messenger];
+    SessionReplayApi *api = [[SessionReplayApi alloc] initWithFlutterApi:flutterApi];
     SessionReplayHostApiSetup(messenger, api);
 }
 
 @implementation SessionReplayApi
+
+- (instancetype)initWithFlutterApi:(SessionReplayFlutterApi *)api {
+    self = [super init];
+    self.flutterApi = api;
+    return self;
+}
 
 - (void)setEnabledIsEnabled:(nonnull NSNumber *)isEnabled error:(FlutterError * _Nullable __autoreleasing * _Nonnull)error {
     LCQSessionReplay.enabled = [isEnabled boolValue];
@@ -50,6 +58,70 @@ extern void InitSessionReplayApi(id<FlutterBinaryMessenger> messenger) {
 - (void)setScreenshotQualityModeMode:(NSString *)mode error:(FlutterError * _Nullable __autoreleasing * _Nonnull)error {
     LCQScreenshotQualityMode nativeMode = (ArgsRegistry.screenshotQualityModes[mode]).integerValue;
     LCQSessionReplay.screenshotQualityMode = nativeMode;
+}
+
+- (NSArray<NSDictionary *> *)serializeNetworkLogs:(NSArray<LCQSessionMetadataNetworkLogs *> *)logs {
+    NSMutableArray<NSDictionary *> *result = [NSMutableArray array];
+    for (LCQSessionMetadataNetworkLogs *log in logs) {
+        [result addObject:@{
+            @"url": log.url ?: [NSNull null],
+            @"duration": @(log.duration),
+            @"statusCode": @(log.statusCode),
+        }];
+    }
+    return result;
+}
+
+- (NSDictionary *)serializeSessionMetadata:(LCQSessionMetadata *)metadata {
+    NSString *launchTypeString;
+    switch (metadata.launchType) {
+        case LaunchTypeCold:
+            launchTypeString = @"Cold";
+            break;
+        case LaunchTypeHot:
+            launchTypeString = @"Hot";
+            break;
+        default:
+            launchTypeString = @"Unknown";
+            break;
+    }
+    return @{
+        @"appVersion": metadata.appVersion ?: [NSNull null],
+        @"os": metadata.os ?: [NSNull null],
+        @"device": metadata.device ?: [NSNull null],
+        @"sessionDurationInSeconds": @(metadata.sessionDuration),
+        @"hasLinkToAppReview": @(metadata.hasLinkToAppReview),
+        @"launchType": launchTypeString,
+        @"launchDuration": @(metadata.launchDuration),
+        @"bugsCount": @(metadata.bugsCount),
+        @"fatalCrashCount": @(metadata.fatalCrashCount),
+        @"oomCrashCount": @(metadata.oomCrashCount),
+        @"networkLogs": [self serializeNetworkLogs:metadata.networkLogs] ?: @[],
+    };
+}
+
+- (void)bindOnSyncCallbackWithError:(FlutterError * _Nullable __autoreleasing * _Nonnull)error {
+    __weak __typeof(self) weakSelf = self;
+    LCQSessionReplay.syncCallbackWithHandler = ^(LCQSessionMetadata *metadataObject, SessionEvaluationCompletion completion) {
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) {
+            completion(YES);
+            return;
+        }
+        strongSelf.pendingSessionEvaluationCompletion = completion;
+        NSDictionary *payload = [strongSelf serializeSessionMetadata:metadataObject];
+        [strongSelf.flutterApi onShouldSyncSessionMetadata:payload
+                                               completion:^(FlutterError * _Nullable _) {
+                                               }];
+    };
+}
+
+- (void)evaluateSyncResult:(NSNumber *)result error:(FlutterError * _Nullable __autoreleasing * _Nonnull)error {
+    void (^completion)(BOOL) = self.pendingSessionEvaluationCompletion;
+    if (completion) {
+        self.pendingSessionEvaluationCompletion = nil;
+        completion([result boolValue]);
+    }
 }
 
 @end

--- a/packages/luciq_flutter/ios/Classes/Modules/SessionReplayApi.m
+++ b/packages/luciq_flutter/ios/Classes/Modules/SessionReplayApi.m
@@ -16,6 +16,7 @@ extern void InitSessionReplayApi(id<FlutterBinaryMessenger> messenger) {
 - (instancetype)initWithFlutterApi:(SessionReplayFlutterApi *)api {
     self = [super init];
     self.flutterApi = api;
+    self.pendingSessionEvaluationCompletions = [NSMutableArray array];
     return self;
 }
 
@@ -96,7 +97,7 @@ extern void InitSessionReplayApi(id<FlutterBinaryMessenger> messenger) {
         @"bugsCount": @(metadata.bugsCount),
         @"fatalCrashCount": @(metadata.fatalCrashCount),
         @"oomCrashCount": @(metadata.oomCrashCount),
-        @"networkLogs": [self serializeNetworkLogs:metadata.networkLogs] ?: @[],
+        @"networkLogs": [self serializeNetworkLogs:metadata.networkLogs],
     };
 }
 
@@ -108,7 +109,9 @@ extern void InitSessionReplayApi(id<FlutterBinaryMessenger> messenger) {
             completion(YES);
             return;
         }
-        strongSelf.pendingSessionEvaluationCompletion = completion;
+        @synchronized (strongSelf.pendingSessionEvaluationCompletions) {
+            [strongSelf.pendingSessionEvaluationCompletions addObject:[completion copy]];
+        }
         NSDictionary *payload = [strongSelf serializeSessionMetadata:metadataObject];
         [strongSelf.flutterApi onShouldSyncSessionMetadata:payload
                                                completion:^(FlutterError * _Nullable _) {
@@ -117,9 +120,14 @@ extern void InitSessionReplayApi(id<FlutterBinaryMessenger> messenger) {
 }
 
 - (void)evaluateSyncResult:(NSNumber *)result error:(FlutterError * _Nullable __autoreleasing * _Nonnull)error {
-    void (^completion)(BOOL) = self.pendingSessionEvaluationCompletion;
+    void (^completion)(BOOL) = nil;
+    @synchronized (self.pendingSessionEvaluationCompletions) {
+        if (self.pendingSessionEvaluationCompletions.count > 0) {
+            completion = self.pendingSessionEvaluationCompletions.firstObject;
+            [self.pendingSessionEvaluationCompletions removeObjectAtIndex:0];
+        }
+    }
     if (completion) {
-        self.pendingSessionEvaluationCompletion = nil;
         completion([result boolValue]);
     }
 }

--- a/packages/luciq_flutter/lib/luciq_flutter.dart
+++ b/packages/luciq_flutter/lib/luciq_flutter.dart
@@ -5,6 +5,7 @@ export 'src/models/exception_data.dart';
 export 'src/models/feature_flag.dart';
 export 'src/models/network_data.dart';
 export 'src/models/proactive_reporting_config.dart';
+export 'src/models/session_metadata.dart';
 export 'src/models/theme_config.dart';
 export 'src/models/w3c_header.dart';
 // Modules

--- a/packages/luciq_flutter/lib/src/models/session_metadata.dart
+++ b/packages/luciq_flutter/lib/src/models/session_metadata.dart
@@ -92,7 +92,7 @@ class SessionMetadata {
     }
     return SessionMetadata(
       appVersion: map['appVersion'] as String?,
-      os: (map['os'] ?? map['OS']) as String?,
+      os: map['os'] as String?,
       device: map['device'] as String?,
       sessionDurationInSeconds:
           (map['sessionDurationInSeconds'] as num?)?.toInt() ?? 0,
@@ -107,29 +107,15 @@ class SessionMetadata {
   }
 
   static LaunchType _parseLaunchType(Object? raw) {
-    if (raw is String) {
-      switch (raw) {
-        case 'Cold':
-          return LaunchType.cold;
-        case 'Warm':
-          return LaunchType.warm;
-        case 'Hot':
-          return LaunchType.hot;
-        default:
-          return LaunchType.unknown;
-      }
+    switch (raw) {
+      case 'Cold':
+        return LaunchType.cold;
+      case 'Warm':
+        return LaunchType.warm;
+      case 'Hot':
+        return LaunchType.hot;
+      default:
+        return LaunchType.unknown;
     }
-    if (raw is num) {
-      // iOS LCQSessionMetadata.launchType: Cold=0, Hot=1, Unknown=-1
-      switch (raw.toInt()) {
-        case 0:
-          return LaunchType.cold;
-        case 1:
-          return LaunchType.hot;
-        default:
-          return LaunchType.unknown;
-      }
-    }
-    return LaunchType.unknown;
   }
 }

--- a/packages/luciq_flutter/lib/src/models/session_metadata.dart
+++ b/packages/luciq_flutter/lib/src/models/session_metadata.dart
@@ -1,0 +1,135 @@
+/// Type of app launch associated with a session.
+///
+/// Values are platform-specific:
+///  * `cold`, `hot`, `unknown` — iOS + Android
+///  * `warm` — Android only
+enum LaunchType { cold, warm, hot, unknown }
+
+/// A single network log captured during a session.
+class NetworkLog {
+  const NetworkLog({
+    required this.url,
+    required this.duration,
+    required this.statusCode,
+  });
+
+  /// The request URL.
+  final String? url;
+
+  /// The request duration in milliseconds.
+  final int duration;
+
+  /// The response status code.
+  final int statusCode;
+
+  /// @nodoc
+  factory NetworkLog.fromMap(Map<Object?, Object?> map) => NetworkLog(
+        url: map['url'] as String?,
+        duration: (map['duration'] as num?)?.toInt() ?? 0,
+        statusCode: (map['statusCode'] as num?)?.toInt() ?? 0,
+      );
+}
+
+/// Metadata about the previous session, passed to [SessionReplay.setSyncCallback].
+class SessionMetadata {
+  const SessionMetadata({
+    this.appVersion,
+    this.os,
+    this.device,
+    this.sessionDurationInSeconds = 0,
+    this.hasLinkToAppReview = false,
+    this.launchType = LaunchType.unknown,
+    this.launchDuration,
+    this.bugsCount = 0,
+    this.fatalCrashCount = 0,
+    this.oomCrashCount = 0,
+    this.networkLogs = const [],
+  });
+
+  /// The app's version string.
+  final String? appVersion;
+
+  /// The OS name/version.
+  final String? os;
+
+  /// The device make and model.
+  final String? device;
+
+  /// The previous session's duration, in seconds.
+  final int sessionDurationInSeconds;
+
+  /// True if an in-app review occurred during the previous session.
+  final bool hasLinkToAppReview;
+
+  /// Launch type of the previous session.
+  final LaunchType launchType;
+
+  /// Launch duration in milliseconds, if measured.
+  final int? launchDuration;
+
+  /// Number of bug reports captured during the previous session (iOS only; 0 on Android).
+  final int bugsCount;
+
+  /// Number of fatal crashes during the previous session (iOS only; 0 on Android).
+  final int fatalCrashCount;
+
+  /// Number of OOM crashes during the previous session (iOS only; 0 on Android).
+  final int oomCrashCount;
+
+  /// Network logs captured during the previous session.
+  final List<NetworkLog> networkLogs;
+
+  /// @nodoc
+  factory SessionMetadata.fromMap(Map<Object?, Object?> map) {
+    final rawLogs = map['networkLogs'];
+    final logs = <NetworkLog>[];
+    if (rawLogs is List) {
+      for (final entry in rawLogs) {
+        if (entry is Map) {
+          logs.add(NetworkLog.fromMap(entry.cast<Object?, Object?>()));
+        }
+      }
+    }
+    return SessionMetadata(
+      appVersion: map['appVersion'] as String?,
+      os: (map['os'] ?? map['OS']) as String?,
+      device: map['device'] as String?,
+      sessionDurationInSeconds:
+          (map['sessionDurationInSeconds'] as num?)?.toInt() ?? 0,
+      hasLinkToAppReview: (map['hasLinkToAppReview'] as bool?) ?? false,
+      launchType: _parseLaunchType(map['launchType']),
+      launchDuration: (map['launchDuration'] as num?)?.toInt(),
+      bugsCount: (map['bugsCount'] as num?)?.toInt() ?? 0,
+      fatalCrashCount: (map['fatalCrashCount'] as num?)?.toInt() ?? 0,
+      oomCrashCount: (map['oomCrashCount'] as num?)?.toInt() ?? 0,
+      networkLogs: logs,
+    );
+  }
+
+  static LaunchType _parseLaunchType(Object? raw) {
+    if (raw is String) {
+      switch (raw) {
+        case 'Cold':
+          return LaunchType.cold;
+        case 'Warm':
+          return LaunchType.warm;
+        case 'Hot':
+          return LaunchType.hot;
+        default:
+          return LaunchType.unknown;
+      }
+    }
+    if (raw is num) {
+      // iOS LCQSessionMetadata.launchType: Cold=0, Hot=1, Unknown=-1
+      switch (raw.toInt()) {
+        case 0:
+          return LaunchType.cold;
+        case 1:
+          return LaunchType.hot;
+        default:
+          return LaunchType.unknown;
+      }
+    }
+    return LaunchType.unknown;
+  }
+}

--- a/packages/luciq_flutter/lib/src/modules/luciq.dart
+++ b/packages/luciq_flutter/lib/src/modules/luciq.dart
@@ -174,6 +174,7 @@ class Luciq {
   static void $setup() {
     BugReporting.$setup();
     Replies.$setup();
+    SessionReplay.$setup();
     Surveys.$setup();
     // Set up LuciqFlutterApi for Android onDestroy disposal
     LuciqFlutterApi.setup(_LuciqDisposalManager.instance);

--- a/packages/luciq_flutter/lib/src/modules/session_replay.dart
+++ b/packages/luciq_flutter/lib/src/modules/session_replay.dart
@@ -2,7 +2,6 @@
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:luciq_flutter/src/generated/session_replay.api.g.dart';
 import 'package:luciq_flutter/src/models/session_metadata.dart';
 import 'package:meta/meta.dart';

--- a/packages/luciq_flutter/lib/src/modules/session_replay.dart
+++ b/packages/luciq_flutter/lib/src/modules/session_replay.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:luciq_flutter/src/generated/session_replay.api.g.dart';
 import 'package:luciq_flutter/src/models/session_metadata.dart';
+import 'package:meta/meta.dart';
 
 enum ScreenshotCapturingMode {
   navigation,

--- a/packages/luciq_flutter/lib/src/modules/session_replay.dart
+++ b/packages/luciq_flutter/lib/src/modules/session_replay.dart
@@ -4,6 +4,8 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:luciq_flutter/src/generated/session_replay.api.g.dart';
+import 'package:luciq_flutter/src/models/session_metadata.dart';
+import 'package:meta/meta.dart';
 
 enum ScreenshotCapturingMode {
   navigation,
@@ -17,14 +19,38 @@ enum ScreenshotQualityMode {
   greyScale,
 }
 
-class SessionReplay {
+typedef SessionSyncCallback = bool Function(SessionMetadata metadata);
+
+class SessionReplay implements SessionReplayFlutterApi {
   static var _host = SessionReplayHostApi();
+  static final _instance = SessionReplay();
+
+  static SessionSyncCallback? _syncCallback;
 
   /// @nodoc
   @visibleForTesting
   // ignore: use_setters_to_change_properties
   static void $setHostApi(SessionReplayHostApi host) {
     _host = host;
+  }
+
+  /// @nodoc
+  @internal
+  static void $setup() {
+    SessionReplayFlutterApi.setup(_instance);
+  }
+
+  /// @nodoc
+  @internal
+  @override
+  void onShouldSyncSession(Map<String?, Object?> metadata) {
+    final cleaned = <Object?, Object?>{};
+    metadata.forEach((key, value) {
+      if (key != null) cleaned[key] = value;
+    });
+    final parsed = SessionMetadata.fromMap(cleaned);
+    final result = _syncCallback?.call(parsed) ?? true;
+    _host.evaluateSync(result);
   }
 
   /// Enables or disables Session Replay for your Luciq integration.
@@ -169,5 +195,22 @@ class SessionReplay {
     ScreenshotQualityMode mode,
   ) async {
     return _host.setScreenshotQualityMode(mode.toString());
+  }
+
+  /// Registers a callback that decides whether to sync a Session Replay.
+  ///
+  /// The callback receives a [SessionMetadata] describing the previous session
+  /// and must return `true` to sync or `false` to drop it.
+  ///
+  /// Example:
+  ///
+  /// ```dart
+  /// SessionReplay.setSyncCallback((metadata) {
+  ///   return metadata.sessionDurationInSeconds > 60;
+  /// });
+  /// ```
+  static Future<void> setSyncCallback(SessionSyncCallback callback) async {
+    _syncCallback = callback;
+    return _host.bindOnSyncCallback();
   }
 }

--- a/packages/luciq_flutter/lib/src/modules/session_replay.dart
+++ b/packages/luciq_flutter/lib/src/modules/session_replay.dart
@@ -5,7 +5,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:luciq_flutter/src/generated/session_replay.api.g.dart';
 import 'package:luciq_flutter/src/models/session_metadata.dart';
-import 'package:meta/meta.dart';
 
 enum ScreenshotCapturingMode {
   navigation,

--- a/packages/luciq_flutter/lib/src/modules/session_replay.dart
+++ b/packages/luciq_flutter/lib/src/modules/session_replay.dart
@@ -34,6 +34,12 @@ class SessionReplay implements SessionReplayFlutterApi {
   }
 
   /// @nodoc
+  @visibleForTesting
+  static void $resetSyncCallback() {
+    _syncCallback = null;
+  }
+
+  /// @nodoc
   @internal
   static void $setup() {
     SessionReplayFlutterApi.setup(_instance);

--- a/packages/luciq_flutter/pigeons/session_replay.api.dart
+++ b/packages/luciq_flutter/pigeons/session_replay.api.dart
@@ -1,11 +1,19 @@
 import 'package:pigeon/pigeon.dart';
 
+@FlutterApi()
+abstract class SessionReplayFlutterApi {
+  void onShouldSyncSession(Map<String, Object?> metadata);
+}
+
 @HostApi()
 abstract class SessionReplayHostApi {
   void setEnabled(bool isEnabled);
   void setNetworkLogsEnabled(bool isEnabled);
   void setLuciqLogsEnabled(bool isEnabled);
   void setUserStepsEnabled(bool isEnabled);
+
+  void bindOnSyncCallback();
+  void evaluateSync(bool result);
 
   @async
   String getSessionReplayLink();

--- a/packages/luciq_flutter/test/session_replay_test.dart
+++ b/packages/luciq_flutter/test/session_replay_test.dart
@@ -20,6 +20,11 @@ void main() {
     SessionReplay.$setHostApi(mHost);
   });
 
+  tearDown(() {
+    SessionReplay.$resetSyncCallback();
+    reset(mHost);
+  });
+
   test('[setEnabled] should call host method', () async {
     const isEnabled = true;
     await SessionReplay.setEnabled(isEnabled);
@@ -187,4 +192,38 @@ void main() {
       verify(mHost.evaluateSync(false)).called(1);
     },
   );
+
+  test('[onShouldSyncSession] should map Android-only Warm launch type',
+      () async {
+    SessionMetadata? received;
+
+    await SessionReplay.setSyncCallback((metadata) {
+      received = metadata;
+      return true;
+    });
+
+    SessionReplay().onShouldSyncSession(const <String?, Object?>{
+      'launchType': 'Warm',
+    });
+
+    expect(received, isNotNull);
+    expect(received!.launchType, LaunchType.warm);
+  });
+
+  test('[onShouldSyncSession] should map unknown launch type strings',
+      () async {
+    SessionMetadata? received;
+
+    await SessionReplay.setSyncCallback((metadata) {
+      received = metadata;
+      return true;
+    });
+
+    SessionReplay().onShouldSyncSession(const <String?, Object?>{
+      'launchType': 'Bogus',
+    });
+
+    expect(received, isNotNull);
+    expect(received!.launchType, LaunchType.unknown);
+  });
 }

--- a/packages/luciq_flutter/test/session_replay_test.dart
+++ b/packages/luciq_flutter/test/session_replay_test.dart
@@ -127,4 +127,64 @@ void main() {
       ),
     ).called(1);
   });
+
+  test(
+    '[onShouldSyncSession] should default to syncing when no callback is set',
+    () async {
+      SessionReplay().onShouldSyncSession(const <String?, Object?>{});
+
+      verify(mHost.evaluateSync(true)).called(1);
+    },
+  );
+
+  test('[setSyncCallback] should bind native callback', () async {
+    await SessionReplay.setSyncCallback((_) => true);
+
+    verify(mHost.bindOnSyncCallback()).called(1);
+  });
+
+  test(
+    '[onShouldSyncSession] should invoke callback and call evaluateSync with its result',
+    () async {
+      SessionMetadata? received;
+
+      await SessionReplay.setSyncCallback((metadata) {
+        received = metadata;
+        return false;
+      });
+
+      final payload = <String?, Object?>{
+        'appVersion': '1.2.3',
+        'os': 'iOS 17.0',
+        'device': 'iPhone15,2',
+        'sessionDurationInSeconds': 42,
+        'hasLinkToAppReview': true,
+        'launchType': 'Cold',
+        'launchDuration': 1500,
+        'bugsCount': 1,
+        'fatalCrashCount': 0,
+        'oomCrashCount': 0,
+        'networkLogs': [
+          {'url': 'https://example.com', 'duration': 120, 'statusCode': 200},
+        ],
+      };
+
+      SessionReplay().onShouldSyncSession(payload);
+
+      expect(received, isNotNull);
+      expect(received!.appVersion, '1.2.3');
+      expect(received!.os, 'iOS 17.0');
+      expect(received!.device, 'iPhone15,2');
+      expect(received!.sessionDurationInSeconds, 42);
+      expect(received!.hasLinkToAppReview, true);
+      expect(received!.launchType, LaunchType.cold);
+      expect(received!.launchDuration, 1500);
+      expect(received!.bugsCount, 1);
+      expect(received!.networkLogs, hasLength(1));
+      expect(received!.networkLogs.first.url, 'https://example.com');
+      expect(received!.networkLogs.first.statusCode, 200);
+
+      verify(mHost.evaluateSync(false)).called(1);
+    },
+  );
 }


### PR DESCRIPTION
## Summary
Adds `SessionReplay.setSyncCallback` for RN parity. The callback receives metadata about the previous session and returns whether the Session Replay should be synced.

Exposes three new Dart types: `SessionMetadata`, `NetworkLog`, and `LaunchType`.

## Bridging approach
Both native SDKs require a synchronous `bool` return from the sync listener — Flutter method channels are async. Mirrors the RN 2-step protocol:
1. `bindOnSyncCallback` installs the native listener, which **enqueues** a completion (iOS) or **awaits a per-invocation `CountDownLatch`** (Android), then fires `onShouldSyncSession(metadata)` on the Flutter side.
2. Dart calls the user's callback, then invokes `evaluateSync(bool)` back on the host.
3. Native pops the next pending completion / latch and resolves it FIFO.

Each invocation owns its own pending entry, so concurrent listener calls cannot overwrite each other's state. Android also bounds the wait with a 5s timeout that falls back to `sync = true` rather than wedging the SDK thread if the Flutter isolate is unresponsive.

## API
```dart
SessionReplay.setSyncCallback((metadata) {
  return metadata.sessionDurationInSeconds > 60 &&
         metadata.launchType == LaunchType.cold;
});
```

## LaunchType mapping
Both platforms send a string (`"Cold" | "Warm" | "Hot"`) over the channel; Dart maps it to `LaunchType.cold | warm | hot | unknown`. `warm` is Android-only; iOS-only fields (`bugsCount`, `fatalCrashCount`, `oomCrashCount`) default to 0 on Android.

## Test plan
- [x] `flutter test test/session_replay_test.dart` — 15/15 pass (5 new, including LaunchType.warm + unknown mapping)
- [x] `./gradlew :luciq_flutter:testDebugUnitTest --tests "ai.luciq.flutter.SessionReplayApiTest"` — 19/19 pass (5 new, including reinvoke-after-evaluate that guards against shared-latch regression)
- [x] `flutter analyze` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)