### PR TITLE
fix(apm): dispatch APM feature-flag checks on background task queue

### DIFF
--- a/packages/luciq_flutter/pigeons/apm.api.dart
+++ b/packages/luciq_flutter/pigeons/apm.api.dart
@@ -42,9 +42,11 @@ abstract class ApmHostApi {
   bool isAutoUiTraceEnabled();
 
   @async
+  @TaskQueue(type: TaskQueueType.serialBackgroundThread)
   bool isScreenRenderEnabled();
 
   @async
+  @TaskQueue(type: TaskQueueType.serialBackgroundThread)
   bool isCustomSpanEnabled();
 
   @async

--- a/packages/luciq_http_client/example/ios/Podfile.lock
+++ b/packages/luciq_http_client/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Flutter (1.0.0)
-  - Luciq (19.4.1)
-  - luciq_flutter (19.4.0):
+  - Luciq (19.6.1)
+  - luciq_flutter (19.6.0):
     - Flutter
-    - Luciq (= 19.4.1)
+    - Luciq (= 19.6.1)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -20,9 +20,9 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/luciq_flutter/ios"
 
 SPEC CHECKSUMS:
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  Luciq: f29a09180b9b23f74f249b88176c73141643f271
-  luciq_flutter: 067dbdd0a83877738be84ba652e6f35ef17af4ff
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  Luciq: 361be18eb534f77063a4df4b64e73a8ff31a60ad
+  luciq_flutter: f5428c8b2cec44ced001719990b4097d066832e4
 
 PODFILE CHECKSUM: 94f53e8d6b63b5d45710485b9afa0e55e8e7e4fb
 

--- a/packages/luciq_http_client/example/pubspec.lock
+++ b/packages/luciq_http_client/example/pubspec.lock
@@ -124,13 +124,12 @@ packages:
     source: hosted
     version: "1.0.1"
   luciq_flutter:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: luciq_flutter
-      sha256: "4e9b77df31857b5491236b23d08699fe9454f8e8c06cdc0b41436015203c9bd2"
-      url: "https://pub.dev"
-    source: hosted
-    version: "19.4.0"
+      path: "../../luciq_flutter"
+      relative: true
+    source: path
+    version: "19.6.0"
   luciq_http_client:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## Description of the change

Annotates the Pigeon `ApmHostApi` methods `isScreenRenderEnabled` and `isCustomSpanEnabled` with `@TaskQueue(type: TaskQueueType.serialBackgroundThread)` so their handlers are dispatched on a Flutter background `TaskQueue` instead of the platform main thread.

### Why

A customer-reported Android App Hang ANR was traced to the main thread being blocked inside the native APM lazy-init graph:

```
BLOCKED Thread 2 main
  ai.luciq.apm.di.i.s/r/u/t
  ai.luciq.apm.InternalAPM$a.invoke
  kotlin.SynchronizedLazyImpl.getValue
  ai.luciq.apm.InternalAPM.getApmImplementation
  ai.luciq.apm.InternalAPM._isFeatureEnabledCP
  ai.luciq.flutter.modules.ApmApi.isScreenRenderEnabled
  ai.luciq.flutter.generated.ApmPigeon$ApmHostApi.o
  ...DartMessenger.invokeHandler
```

Multiple LUCIQ background threads were simultaneously `BLOCKED` on the same `SynchronizedLazyImpl` monitor (`LUCIQ-API-executor-0`, `LUCIQ-core-io-executor-*`, `LUCIQ-network-single-executor-*`, `LUCIQ-ui-traces-executor-0`). The Flutter -> native call landed on the platform main thread mid-contention and crossed the 3000ms ANR threshold.

Moving the Pigeon dispatch off the main thread prevents the ANR. The Dart-side callers already `await` the Future, so the threading-contract change is safe.

### Note

This is a mitigation for the symptom. The underlying native-SDK lazy-init contention (`ai.luciq.apm.di.*`, `ai.luciq.apm.screenrendering.di.d`) should be addressed separately.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request

## Test plan

- [ ] Run `melos pigeon --no-select` in a clean checkout and verify the regenerated Java (`ApmPigeon.java`) calls `binaryMessenger.makeBackgroundTaskQueue()` for both methods.
- [ ] Run `melos analyze` and `melos test`.
- [ ] Manually verify on Android: launch app under load with APM enabled and confirm no ANR with the `ApmApi.isScreenRenderEnabled` / `isCustomSpanEnabled` signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)