### PR TITLE
fix: prevent PixelCopy crash on invalid surface during capture

### DIFF
--- a/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/PrivateViewManager.java
+++ b/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/PrivateViewManager.java
@@ -57,7 +57,8 @@ public class PrivateViewManager {
 
 
     public void mask(ScreenshotCaptor.CapturingCallback capturingCallback) {
-        if (activity != null) {
+        final Activity captureActivity = activity;
+        if (isActivityValid(captureActivity)) {
             CountDownLatch latch = new CountDownLatch(1);
             AtomicReference<List<Double>> privateViews = new AtomicReference<>();
             final ScreenshotResultCallback boundryScreenshotResult = new ScreenshotResultCallback() {
@@ -96,12 +97,16 @@ public class PrivateViewManager {
 
                         @Override
                         public void onError() {
-                            boundryScreenshotCaptor.capture(activity, boundryScreenshotResult);
+                            if (isActivityValid(captureActivity)) {
+                                boundryScreenshotCaptor.capture(captureActivity, boundryScreenshotResult);
+                            } else {
+                                capturingCallback.onCapturingFailure(new Exception(EXCEPTION_MESSAGE));
+                            }
 
                         }
                     };
 
-                    windowPixelCopyScreenshotCaptor.capture(activity, new ScreenshotResultCallback() {
+                    windowPixelCopyScreenshotCaptor.capture(captureActivity, new ScreenshotResultCallback() {
                         @Override
                         public void onScreenshotResult(ScreenshotResult result) {
                             processScreenshot(result, privateViews, latch, capturingCallback);
@@ -109,12 +114,16 @@ public class PrivateViewManager {
 
                         @Override
                         public void onError() {
-                            pixelCopyScreenshotCaptor.capture(activity, pixelCopyScreenshotResult);
+                            if (isActivityValid(captureActivity)) {
+                                pixelCopyScreenshotCaptor.capture(captureActivity, pixelCopyScreenshotResult);
+                            } else {
+                                capturingCallback.onCapturingFailure(new Exception(EXCEPTION_MESSAGE));
+                            }
 
                         }
                     });
                 } else {
-                    boundryScreenshotCaptor.capture(activity, boundryScreenshotResult);
+                    boundryScreenshotCaptor.capture(captureActivity, boundryScreenshotResult);
                 }
 
             } catch (Exception e) {
@@ -123,6 +132,14 @@ public class PrivateViewManager {
         } else {
             capturingCallback.onCapturingFailure(new Exception(EXCEPTION_MESSAGE));
         }
+    }
+
+    private boolean isActivityValid(Activity activity) {
+        if (activity == null || activity.getWindow() == null || activity.isFinishing()) {
+            return false;
+        }
+
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1 || !activity.isDestroyed();
     }
 
 

--- a/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/capturing/PixelCopyCaptureManager.java
+++ b/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/capturing/PixelCopyCaptureManager.java
@@ -7,6 +7,8 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.DisplayMetrics;
 import android.view.PixelCopy;
+import android.view.Surface;
+import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 
 import androidx.annotation.RequiresApi;
@@ -30,6 +32,11 @@ public class PixelCopyCaptureManager implements CaptureManager {
         }
 
         SurfaceView surfaceView = (SurfaceView) flutterView.getChildAt(0);
+        if (!isValidSurface(surfaceView)) {
+            screenshotResultCallback.onError();
+            return;
+        }
+
         Bitmap bitmap = createBitmapFromSurface(surfaceView);
 
         if (bitmap == null) {
@@ -37,14 +44,22 @@ public class PixelCopyCaptureManager implements CaptureManager {
             return;
         }
 
-        PixelCopy.request(surfaceView, bitmap, copyResult -> {
-            if (copyResult == PixelCopy.SUCCESS) {
-                DisplayMetrics displayMetrics = activity.getResources().getDisplayMetrics();
-                screenshotResultCallback.onScreenshotResult(new ScreenshotResult(displayMetrics.density, bitmap));
-            } else {
-                screenshotResultCallback.onError();
-            }
-        }, new Handler(Looper.getMainLooper()));
+        try {
+            PixelCopy.request(surfaceView, bitmap, copyResult -> {
+                try {
+                    if (copyResult == PixelCopy.SUCCESS) {
+                        DisplayMetrics displayMetrics = activity.getResources().getDisplayMetrics();
+                        screenshotResultCallback.onScreenshotResult(new ScreenshotResult(displayMetrics.density, bitmap));
+                    } else {
+                        screenshotResultCallback.onError();
+                    }
+                } catch (Exception e) {
+                    screenshotResultCallback.onError();
+                }
+            }, new Handler(Looper.getMainLooper()));
+        } catch (Exception e) {
+            screenshotResultCallback.onError();
+        }
     }
 
     private FlutterView getFlutterView(Activity activity) {
@@ -57,6 +72,16 @@ public class PixelCopyCaptureManager implements CaptureManager {
         boolean hasChildren = flutterView.getChildCount() > 0;
         boolean isSurfaceView = flutterView.getChildAt(0) instanceof SurfaceView;
         return hasChildren && isSurfaceView;
+    }
+
+    private boolean isValidSurface(SurfaceView surfaceView) {
+        SurfaceHolder holder = surfaceView.getHolder();
+        if (holder == null) {
+            return false;
+        }
+
+        Surface surface = holder.getSurface();
+        return surface != null && surface.isValid();
     }
 
     private Bitmap createBitmapFromSurface(SurfaceView surfaceView) {

--- a/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/capturing/WindowPixelCopyCaptureManager.java
+++ b/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/capturing/WindowPixelCopyCaptureManager.java
@@ -37,15 +37,19 @@ public class WindowPixelCopyCaptureManager implements CaptureManager {
 
         try {
             PixelCopy.request(activity.getWindow(), null, bitmap, copyResult -> {
-                if (copyResult == PixelCopy.SUCCESS) {
-                    if (isInvalidWindowCapture(bitmap)) {
+                try {
+                    if (copyResult == PixelCopy.SUCCESS) {
+                        if (isInvalidWindowCapture(bitmap)) {
+                            screenshotResultCallback.onError();
+                            return;
+                        }
+                        DisplayMetrics displayMetrics = activity.getResources().getDisplayMetrics();
+                        float[] flutterViewOffset = getFlutterViewOffset(activity, rootView, displayMetrics.density);
+                        screenshotResultCallback.onScreenshotResult(new ScreenshotResult(displayMetrics.density, bitmap, flutterViewOffset[0], flutterViewOffset[1]));
+                    } else {
                         screenshotResultCallback.onError();
-                        return;
                     }
-                    DisplayMetrics displayMetrics = activity.getResources().getDisplayMetrics();
-                    float[] flutterViewOffset = getFlutterViewOffset(activity, rootView, displayMetrics.density);
-                    screenshotResultCallback.onScreenshotResult(new ScreenshotResult(displayMetrics.density, bitmap, flutterViewOffset[0], flutterViewOffset[1]));
-                } else {
+                } catch (Exception e) {
                     screenshotResultCallback.onError();
                 }
             }, new Handler(Looper.getMainLooper()));

--- a/packages/luciq_flutter/android/src/test/java/ai/luciq/flutter/util/private_views/PixelCopyScreenshotCaptorTest.java
+++ b/packages/luciq_flutter/android/src/test/java/ai/luciq/flutter/util/private_views/PixelCopyScreenshotCaptorTest.java
@@ -12,6 +12,8 @@ import static org.robolectric.Shadows.shadowOf;
 import android.app.Activity;
 import android.graphics.Bitmap;
 import android.os.Looper;
+import android.view.Surface;
+import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 
 import ai.luciq.flutter.model.ScreenshotResult;
@@ -76,16 +78,36 @@ public class PixelCopyScreenshotCaptorTest {
         }
     }
 
+    @Test
+    public void testCaptureWithPixelCopyGivenInvalidSurface() {
+        SurfaceView surfaceView = mockFlutterViewInPixelCopy();
+        Surface invalidSurface = mock(Surface.class);
+        when(invalidSurface.isValid()).thenReturn(false);
+        when(surfaceView.getHolder().getSurface()).thenReturn(invalidSurface);
 
-    private void mockFlutterViewInPixelCopy() {
+        ScreenshotResultCallback mockScreenshotResultCallback = mock(ScreenshotResultCallback.class);
 
-            SurfaceView mockSurfaceView = mock(SurfaceView.class);
-            FlutterView flutterView = mock(FlutterView.class);
-            when(flutterView.getChildAt(0)).thenReturn(mockSurfaceView);
-            when(flutterView.getChildCount()).thenReturn(1);
+        captureManager.capture(activityMock, mockScreenshotResultCallback);
 
-            when(activityMock.findViewById(FlutterActivity.FLUTTER_VIEW_ID)).thenReturn(flutterView);
-            when(mockSurfaceView.getWidth()).thenReturn(100);
-            when(mockSurfaceView.getHeight()).thenReturn(100);
-        }
+        verify(mockScreenshotResultCallback).onError();
+    }
+
+
+    private SurfaceView mockFlutterViewInPixelCopy() {
+        SurfaceView mockSurfaceView = mock(SurfaceView.class);
+        SurfaceHolder surfaceHolder = mock(SurfaceHolder.class);
+        Surface surface = mock(Surface.class);
+        FlutterView flutterView = mock(FlutterView.class);
+        when(flutterView.getChildAt(0)).thenReturn(mockSurfaceView);
+        when(flutterView.getChildCount()).thenReturn(1);
+
+        when(activityMock.findViewById(FlutterActivity.FLUTTER_VIEW_ID)).thenReturn(flutterView);
+        when(mockSurfaceView.getWidth()).thenReturn(100);
+        when(mockSurfaceView.getHeight()).thenReturn(100);
+        when(mockSurfaceView.getHolder()).thenReturn(surfaceHolder);
+        when(surfaceHolder.getSurface()).thenReturn(surface);
+        when(surface.isValid()).thenReturn(true);
+
+        return mockSurfaceView;
+    }
 }

--- a/packages/luciq_flutter/android/src/test/java/ai/luciq/flutter/util/private_views/PrivateViewManagerTest.java
+++ b/packages/luciq_flutter/android/src/test/java/ai/luciq/flutter/util/private_views/PrivateViewManagerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Activity;
@@ -147,6 +148,25 @@ public class PrivateViewManagerTest {
         verify(windowPixelCopyScreenCaptor).capture(any(), any());
         verify(pixelCopyScreenCaptor).capture(any(), any());
         verify(boundryScreenCaptor, never()).capture(any(), any());
+    }
+
+    @Test
+    public void testMaskShouldNotFallbackToPixelCopyWhenActivityIsFinishing() {
+        ScreenshotCaptor.CapturingCallback capturingCallbackMock = mock(ScreenshotCaptor.CapturingCallback.class);
+        doAnswer(invocation -> {
+            when(activityMock.isFinishing()).thenReturn(true);
+            ScreenshotResultCallback callback = invocation.getArgument(1);
+            callback.onError();
+            return null;
+        }).when(windowPixelCopyScreenCaptor).capture(any(), any());
+
+        privateViewManager.mask(capturingCallbackMock);
+        shadowOf(Looper.getMainLooper()).idle();
+
+        verify(windowPixelCopyScreenCaptor).capture(any(), any());
+        verify(pixelCopyScreenCaptor, never()).capture(any(), any());
+        verify(boundryScreenCaptor, never()).capture(any(), any());
+        verify(capturingCallbackMock).onCapturingFailure(any(Throwable.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fixes `java.lang.IllegalArgumentException: Surface isn't valid, source.isValid() == false` crashing host apps from `ai.luciq.flutter.modules.capturing.PixelCopyCaptureManager`.
- Reported in WebView/Liveness flows: window capture returns a blank/black frame, falls back to the Flutter `SurfaceView` PixelCopy, and the native `Surface` is already invalid mid-teardown.

## Changes
- `PixelCopyCaptureManager`: validate `SurfaceHolder.getSurface().isValid()` before allocating/requesting; wrap both the synchronous `PixelCopy.request` call and its async callback body so failures degrade to `onError()` (graceful fallback) instead of crashing.
- `WindowPixelCopyCaptureManager`: protect the async PixelCopy callback body against the same teardown-time failures (`getPixel`, `getLocationInWindow`, `getResources`).
- `PrivateViewManager`: snapshot the `Activity` at capture start and skip fallback captures when it is finishing/destroyed, avoiding capture attempts on a torn-down window.

## Defense in depth
1. `PrivateViewManager` skips fallback when activity is invalid.
2. `PixelCopyCaptureManager` validates surface + catches sync/async throws.
3. `WindowPixelCopyCaptureManager` catches sync/async throws.

## Test plan
- [x] `./gradlew :luciq_flutter:testDebugUnitTest --tests 'ai.luciq.flutter.util.private_views.*'`
- [x] Added `testCaptureWithPixelCopyGivenInvalidSurface` (invalid surface -> onError)
- [x] Added `testMaskShouldNotFallbackToPixelCopyWhenActivityIsFinishing` (finishing activity -> no fallback, failure reported)
- [x] Existing fallback/capture tests still pass
