### PR TITLE
feat: support user event parameters

### DIFF
--- a/packages/luciq_flutter/CHANGELOG.md
+++ b/packages/luciq_flutter/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## [Unreleased](https://github.com/luciqai/luciq-flutter-sdk/compare/v19.8.0...dev)
+
+### Added
+
+- Add support for logging user events with key-value parameters using `UserEventParam`. ([#70](https://github.com/luciqai/luciq-flutter-sdk/pull/70))
+
 ## [19.8.0](https://github.com/luciqai/luciq-flutter-sdk/compare/v19.8.0...19.7.0)
 
 ### Add

--- a/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/LuciqApi.java
+++ b/packages/luciq_flutter/android/src/main/java/ai/luciq/flutter/modules/LuciqApi.java
@@ -52,6 +52,7 @@ import ai.luciq.library.invocation.LuciqInvocationEvent;
 import ai.luciq.library.model.NetworkLog;
 import ai.luciq.library.screenshot.instacapture.ScreenshotRequest;
 import ai.luciq.library.ui.onboarding.WelcomeMessage;
+import ai.luciq.library.user.UserEventParam;
 import io.flutter.FlutterInjector;
 import io.flutter.embedding.engine.loader.FlutterLoader;
 import io.flutter.plugin.common.BinaryMessenger;
@@ -243,10 +244,18 @@ public class LuciqApi implements LuciqPigeon.LuciqHostApi {
     }
 
     @Override
-    public void logUserEvent(@NonNull String name) {
+    public void logUserEvent(@NonNull String name, @NonNull Map<String, String> parameters) {
         LuciqFlutterLogger.d(LuciqFlutterDebugTags.CORE,
-                "[Luciq.logUserEvent] phase=enter length=" + name.length());
-        Luciq.logUserEvent(name);
+                "[Luciq.logUserEvent] phase=enter length=" + name.length() + " parametersCount=" + parameters.size());
+        if (parameters.isEmpty()) {
+            Luciq.logUserEvent(name);
+        } else {
+            List<UserEventParam> userEventParams = new ArrayList<>();
+            for (Map.Entry<String, String> entry : parameters.entrySet()) {
+                userEventParams.add(new UserEventParam(entry.getKey(), entry.getValue()));
+            }
+            Luciq.logUserEvent(name, userEventParams.toArray(new UserEventParam[0]));
+        }
         LuciqFlutterLogger.d(LuciqFlutterDebugTags.CORE, "[Luciq.logUserEvent] phase=exit");
     }
 

--- a/packages/luciq_flutter/android/src/test/java/ai/luciq/flutter/LuciqApiTest.java
+++ b/packages/luciq_flutter/android/src/test/java/ai/luciq/flutter/LuciqApiTest.java
@@ -59,6 +59,7 @@ import ai.luciq.library.invocation.LuciqInvocationEvent;
 import ai.luciq.library.model.NetworkLog;
 import ai.luciq.library.screenshot.ScreenshotCaptor;
 import ai.luciq.library.ui.onboarding.WelcomeMessage;
+import ai.luciq.library.user.UserEventParam;
 import ai.luciq.survey.Surveys;
 import ai.luciq.survey.callbacks.OnShowCallback;
 
@@ -259,9 +260,20 @@ public class LuciqApiTest {
     public void testLogUserEvent() {
         String event = "sign_up";
 
-        api.logUserEvent(event);
+        api.logUserEvent(event, Collections.emptyMap());
 
         mLuciq.verify(() -> Luciq.logUserEvent(event));
+    }
+
+    @Test
+    public void testLogUserEventWithParameters() {
+        String event = "Completed Purchase";
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("item", "Premium Plan");
+
+        api.logUserEvent(event, parameters);
+
+        mLuciq.verify(() -> Luciq.logUserEvent(eq(event), any(UserEventParam.class)));
     }
 
     @Test

--- a/packages/luciq_flutter/example/ios/LuciqTests/LuciqApiTests.m
+++ b/packages/luciq_flutter/example/ios/LuciqTests/LuciqApiTests.m
@@ -97,9 +97,19 @@
     NSString *name = @"sign_up";
     FlutterError *error;
 
-    [self.api logUserEventName:name error:&error];
+    [self.api logUserEventName:name parameters:@{} error:&error];
 
     OCMVerify([self.mLuciq logUserEventWithName:name]);
+}
+
+- (void)testLogUserEventWithParameters {
+    NSString *name = @"Completed Purchase";
+    NSDictionary<NSString *, NSString *> *parameters = @{@"item": @"Premium Plan"};
+    FlutterError *error;
+
+    [self.api logUserEventName:name parameters:parameters error:&error];
+
+    OCMVerify([self.mLuciq logUserEventWithName:name parameters:[OCMArg any]]);
 }
 
 - (void)testLogOut {

--- a/packages/luciq_flutter/example/lib/src/screens/core_page.dart
+++ b/packages/luciq_flutter/example/lib/src/screens/core_page.dart
@@ -14,6 +14,8 @@ class _CorePageState extends State<CorePage> {
 
   final userDataController = TextEditingController();
   final userEventController = TextEditingController();
+  final userEventParamKeyController = TextEditingController();
+  final userEventParamValueController = TextEditingController();
   final userEmailController = TextEditingController();
   final userNameController = TextEditingController();
   final userIdController = TextEditingController();
@@ -39,9 +41,19 @@ class _CorePageState extends State<CorePage> {
 
   void addUserEvent() {
     if (userEventController.text.isNotEmpty) {
-      Luciq.logUserEvent(userEventController.text);
+      final parameters = userEventParamKeyController.text.isNotEmpty
+          ? [
+              UserEventParam(
+                key: userEventParamKeyController.text,
+                value: userEventParamValueController.text,
+              ),
+            ]
+          : <UserEventParam>[];
+      Luciq.logUserEvent(userEventController.text, parameters: parameters);
     }
     userEventController.text = '';
+    userEventParamKeyController.text = '';
+    userEventParamValueController.text = '';
   }
 
   void addTag() {
@@ -104,6 +116,8 @@ class _CorePageState extends State<CorePage> {
   void dispose() {
     userDataController.dispose();
     userEventController.dispose();
+    userEventParamKeyController.dispose();
+    userEventParamValueController.dispose();
     userEmailController.dispose();
     userNameController.dispose();
     userIdController.dispose();
@@ -201,6 +215,16 @@ class _CorePageState extends State<CorePage> {
           controller: userEventController,
           label: 'Enter event name',
           symanticLabel: 'user_event_input',
+        ),
+        LuciqTextField(
+          controller: userEventParamKeyController,
+          label: 'Enter parameter key (optional)',
+          symanticLabel: 'user_event_param_key_input',
+        ),
+        LuciqTextField(
+          controller: userEventParamValueController,
+          label: 'Enter parameter value (optional)',
+          symanticLabel: 'user_event_param_value_input',
         ),
         LuciqButton(
           text: 'Log User Event',

--- a/packages/luciq_flutter/ios/Classes/Modules/LuciqApi.m
+++ b/packages/luciq_flutter/ios/Classes/Modules/LuciqApi.m
@@ -126,9 +126,17 @@ extern void InitLuciqApi(id<FlutterBinaryMessenger> messenger) {
     [LuciqFlutterLogger d:[LuciqFlutterDebugTags core] format:@"[Luciq.setUserData] phase=exit"];
 }
 
-- (void)logUserEventName:(NSString *)name error:(FlutterError *_Nullable *_Nonnull)error {
-    [LuciqFlutterLogger d:[LuciqFlutterDebugTags core] format:@"[Luciq.logUserEvent] phase=enter nameLength=%lu", (unsigned long)name.length];
-    [Luciq logUserEventWithName:name];
+- (void)logUserEventName:(NSString *)name parameters:(NSDictionary<NSString *, NSString *> *)parameters error:(FlutterError *_Nullable *_Nonnull)error {
+    [LuciqFlutterLogger d:[LuciqFlutterDebugTags core] format:@"[Luciq.logUserEvent] phase=enter nameLength=%lu parametersCount=%lu", (unsigned long)name.length, (unsigned long)parameters.count];
+    if (parameters.count == 0) {
+        [Luciq logUserEventWithName:name];
+    } else {
+        NSMutableArray<LCQUserEventParam *> *userEventParams = [NSMutableArray arrayWithCapacity:parameters.count];
+        [parameters enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, BOOL *stop) {
+            [userEventParams addObject:[[LCQUserEventParam alloc] initWithKey:key value:value]];
+        }];
+        [Luciq logUserEventWithName:name parameters:userEventParams];
+    }
     [LuciqFlutterLogger d:[LuciqFlutterDebugTags core] format:@"[Luciq.logUserEvent] phase=exit"];
 }
 

--- a/packages/luciq_flutter/lib/luciq_flutter.dart
+++ b/packages/luciq_flutter/lib/luciq_flutter.dart
@@ -6,6 +6,7 @@ export 'src/models/feature_flag.dart';
 export 'src/models/network_data.dart';
 export 'src/models/proactive_reporting_config.dart';
 export 'src/models/theme_config.dart';
+export 'src/models/user_event_param.dart';
 export 'src/models/w3c_header.dart';
 // Modules
 export 'src/modules/apm.dart';

--- a/packages/luciq_flutter/lib/src/models/user_event_param.dart
+++ b/packages/luciq_flutter/lib/src/models/user_event_param.dart
@@ -1,0 +1,10 @@
+/// A key-value parameter that can be attached to a user event.
+class UserEventParam {
+  /// The parameter key.
+  String key;
+
+  /// The parameter value.
+  String value;
+
+  UserEventParam({required this.key, required this.value});
+}

--- a/packages/luciq_flutter/lib/src/modules/luciq.dart
+++ b/packages/luciq_flutter/lib/src/modules/luciq.dart
@@ -803,7 +803,6 @@ class Luciq {
     PrivateViewsManager.I.addAutoMasking(types);
   }
 
-
   /// Enables and disables manual invocation and prompt options for bug and feedback.
   /// [boolean] isEnabled
   static Future<void> logUserSteps(

--- a/packages/luciq_flutter/lib/src/modules/luciq.dart
+++ b/packages/luciq_flutter/lib/src/modules/luciq.dart
@@ -435,9 +435,9 @@ class Luciq {
   /// Logged user events are going to be sent with each report, as well as at the end of a session.
   /// Optionally attach key-value [parameters] to enrich the event.
   static Future<void> logUserEvent(
-    String name, [
+    String name, {
     List<UserEventParam> parameters = const [],
-  ]) {
+  }) {
     final parametersMap = {
       for (final param in parameters) param.key: param.value,
     };

--- a/packages/luciq_flutter/lib/src/modules/luciq.dart
+++ b/packages/luciq_flutter/lib/src/modules/luciq.dart
@@ -433,12 +433,24 @@ class Luciq {
 
   /// Logs a user event with [name] that happens through the lifecycle of the application.
   /// Logged user events are going to be sent with each report, as well as at the end of a session.
-  static Future<void> logUserEvent(String name) => hostCall(
-        'Luciq.logUserEvent',
-        () => _host.logUserEvent(name),
-        tag: DebugTags.core,
-        args: {'nameLength': name.length},
-      );
+  /// Optionally attach key-value [parameters] to enrich the event.
+  static Future<void> logUserEvent(
+    String name, [
+    List<UserEventParam> parameters = const [],
+  ]) {
+    final parametersMap = {
+      for (final param in parameters) param.key: param.value,
+    };
+    return hostCall(
+      'Luciq.logUserEvent',
+      () => _host.logUserEvent(name, parametersMap),
+      tag: DebugTags.core,
+      args: {
+        'nameLength': name.length,
+        'parametersCount': parameters.length,
+      },
+    );
+  }
 
   /// Overrides any of the strings shown in the SDK with custom ones.
   /// Allows you to customize a [value] shown to users in the SDK using a predefined [key].

--- a/packages/luciq_flutter/pigeons/luciq.api.dart
+++ b/packages/luciq_flutter/pigeons/luciq.api.dart
@@ -43,7 +43,7 @@ abstract class LuciqHostApi {
 
   void setAppVariant(String appVariant);
 
-  void logUserEvent(String name);
+  void logUserEvent(String name, Map<String, String> parameters);
 
   void logOut();
 

--- a/packages/luciq_flutter/test/luciq_test.dart
+++ b/packages/luciq_flutter/test/luciq_test.dart
@@ -178,7 +178,7 @@ void main() {
       UserEventParam(key: 'currency', value: 'USD'),
     ];
 
-    await Luciq.logUserEvent(event, parameters);
+    await Luciq.logUserEvent(event, parameters: parameters);
 
     verify(
       mHost.logUserEvent(event, {'item': 'Premium Plan', 'currency': 'USD'}),

--- a/packages/luciq_flutter/test/luciq_test.dart
+++ b/packages/luciq_flutter/test/luciq_test.dart
@@ -167,7 +167,21 @@ void main() {
     await Luciq.logUserEvent(event);
 
     verify(
-      mHost.logUserEvent(event),
+      mHost.logUserEvent(event, {}),
+    ).called(1);
+  });
+
+  test('[logUserEvent] should call host method with parameters', () async {
+    const event = "Completed Purchase";
+    final parameters = [
+      UserEventParam(key: 'item', value: 'Premium Plan'),
+      UserEventParam(key: 'currency', value: 'USD'),
+    ];
+
+    await Luciq.logUserEvent(event, parameters);
+
+    verify(
+      mHost.logUserEvent(event, {'item': 'Premium Plan', 'currency': 'USD'}),
     ).called(1);
   });
 


### PR DESCRIPTION
## Description of the change

Adds support for attaching key-value parameters to user event logs, matching the React Native SDK feature.

- New public `UserEventParam` model (`{ key, value }`), exported from `luciq_flutter.dart`.
- `Luciq.logUserEvent(name)` is overloaded to `Luciq.logUserEvent(name, [List<UserEventParam> parameters])`. Backward compatible: existing single-argument calls keep working and fall back to the parameterless native API when no params are passed.
- Pigeon schema updated: `logUserEvent(String name, Map<String, String> parameters)`. The Dart layer converts the `List<UserEventParam>` to a `Map<String,String>` for the wire (consistent with the existing `addFeatureFlags(Map)` pattern); generated bridge files regenerated via `scripts/pigeon.sh`.
- Native host impls:
  - iOS: builds `NSArray<LCQUserEventParam *>` and calls `logUserEventWithName:parameters:` (Luciq iOS 19.8.1).
  - Android: builds `UserEventParam[]` and calls `Luciq.logUserEvent(name, params)` (Luciq Android 19.8.0).
- Validation (trim, empty, length, max-count, duplicate keys) is owned by the native core SDKs.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> [Issue links go here](https://instabug.atlassian.net/browse/MOB-22691)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request

🤖 Generated with [Claude Code](https://claude.com/claude-code)
