### PR TITLE
ci: add release-snapshot script and CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,31 @@
 version: 2.1
 
 parameters:
-  run_snapshot:
+  # --- Task: generate a generic snapshot (scripts/snapshot.sh) ---
+  run_generate_snapshot:
     type: boolean
     default: false
-  snapshot_version:
+  snapshot_ticket:
     type: string
     default: ""
-  snapshot_prefix:
+
+  # --- Task: release a bdr-thermea release (scripts/release-snapshot.sh) ---
+  run_release:
+    type: boolean
+    default: false
+  release_version:
+    type: string
+    default: ""
+  release_prefix:
     type: string
     default: "bdr-thermea"
-  snapshot_base_branch:
+  release_base_branch:
     type: string
     default: "master"
-  snapshot_android_sdk:
+  release_android_sdk:
     type: string
     default: ""
-  snapshot_ios_sdk:
+  release_ios_sdk:
     type: string
     default: ""
 
@@ -553,7 +562,8 @@ jobs:
           working_directory: packages/luciq_flutter
           command: Escape flutter publish-monorepo-luciq
 
-  create_release_snapshot:
+  # Task: generate a generic snapshot branch (snapshot/<version>-<ticket>).
+  generate_snapshot:
     executor: flutter-executor
     steps:
       - advanced-checkout/shallow-checkout
@@ -566,17 +576,41 @@ jobs:
             git config user.email "luciq-ci@luciq.ai"
             git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/luciqai/luciq-flutter-sdk.git"
       - run:
-          name: Create and push release snapshot
+          name: Generate and push snapshot
           command: |
-            VERSION="<< pipeline.parameters.snapshot_version >>"
+            TICKET="<< pipeline.parameters.snapshot_ticket >>"
+            if [ -z "$TICKET" ]; then
+              echo "snapshot_ticket pipeline parameter is required" >&2
+              exit 1
+            fi
+            # Generation already ran via setup_flutter, so skip pigeon in the script (-s).
+            bash scripts/snapshot.sh -s -t "$TICKET"
+
+  # Task: cut a bdr-thermea release branch (release/<prefix>-<version>).
+  release_bdr_thermea:
+    executor: flutter-executor
+    steps:
+      - advanced-checkout/shallow-checkout
+      - generate_luciq_github_app_token
+      - setup_flutter
+      - run:
+          name: Configure git for push
+          command: |
+            git config user.name "luciq-ci[bot]"
+            git config user.email "luciq-ci@luciq.ai"
+            git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/luciqai/luciq-flutter-sdk.git"
+      - run:
+          name: Create and push release
+          command: |
+            VERSION="<< pipeline.parameters.release_version >>"
             if [ -z "$VERSION" ]; then
-              echo "snapshot_version pipeline parameter is required" >&2
+              echo "release_version pipeline parameter is required" >&2
               exit 1
             fi
             # Generation already ran via setup_flutter, so skip it in the script (-s).
-            ARGS="-s -v $VERSION -p << pipeline.parameters.snapshot_prefix >> -b << pipeline.parameters.snapshot_base_branch >>"
-            ANDROID_SDK="<< pipeline.parameters.snapshot_android_sdk >>"
-            IOS_SDK="<< pipeline.parameters.snapshot_ios_sdk >>"
+            ARGS="-s -v $VERSION -p << pipeline.parameters.release_prefix >> -b << pipeline.parameters.release_base_branch >>"
+            ANDROID_SDK="<< pipeline.parameters.release_android_sdk >>"
+            IOS_SDK="<< pipeline.parameters.release_ios_sdk >>"
             [ -n "$ANDROID_SDK" ] && ARGS="$ARGS --android-sdk $ANDROID_SDK"
             [ -n "$IOS_SDK" ] && ARGS="$ARGS --ios-sdk $IOS_SDK"
             bash scripts/release-snapshot.sh $ARGS
@@ -595,13 +629,21 @@ jobs:
 
 workflows:
   version: 2
-  release-snapshot:
-    when: << pipeline.parameters.run_snapshot >>
+  generate-snapshot:
+    when: << pipeline.parameters.run_generate_snapshot >>
     jobs:
-      - create_release_snapshot
+      - generate_snapshot
+
+  release-bdr-thermea:
+    when: << pipeline.parameters.run_release >>
+    jobs:
+      - release_bdr_thermea
 
   build-test-and-approval-deploy:
-    unless: << pipeline.parameters.run_snapshot >>
+    unless:
+      or:
+        - << pipeline.parameters.run_generate_snapshot >>
+        - << pipeline.parameters.run_release >>
     jobs:
       - test_android
       - danger:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -566,7 +566,7 @@ jobs:
         default: "bdr-thermea"
       base_branch:
         type: string
-        default: "master"
+        default: ""
       android_sdk:
         type: string
         default: ""
@@ -587,12 +587,16 @@ jobs:
       - run:
           name: Create and push release
           # Version defaults to the version already in pubspec.yaml when left empty.
+          # Base branch defaults to the branch this pipeline runs on ($CIRCLE_BRANCH).
           # Generation already ran via setup_flutter, so skip it in the script (-s).
           command: |
-            ARGS="-s -p << parameters.prefix >> -b << parameters.base_branch >>"
+            ARGS="-s -p << parameters.prefix >>"
             VERSION="<< parameters.version >>"
+            BASE="<< parameters.base_branch >>"
             ANDROID_SDK="<< parameters.android_sdk >>"
             IOS_SDK="<< parameters.ios_sdk >>"
+            [ -z "$BASE" ] && BASE="$CIRCLE_BRANCH"
+            ARGS="$ARGS -b $BASE"
             [ -n "$VERSION" ] && ARGS="$ARGS -v $VERSION"
             [ -n "$ANDROID_SDK" ] && ARGS="$ARGS --android-sdk $ANDROID_SDK"
             [ -n "$IOS_SDK" ] && ARGS="$ARGS --ios-sdk $IOS_SDK"
@@ -755,20 +759,15 @@ workflows:
               only: master
       # Manual switch: approve to cut a bdr-thermea release branch.
       # Leave version empty to use the version already in pubspec.yaml.
+      # Base branch defaults to the branch this pipeline runs on.
       - hold_release_bdr_thermea:
           type: approval
-          filters:
-            branches:
-              only: master
       - release_bdr_thermea:
           version: ""
           prefix: "bdr-thermea"
-          base_branch: "master"
+          base_branch: ""
           requires:
             - hold_release_bdr_thermea
-          filters:
-            branches:
-              only: master
 
   send-release-notes-to-test-channel:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,25 @@
 version: 2.1
 
+parameters:
+  run_snapshot:
+    type: boolean
+    default: false
+  snapshot_version:
+    type: string
+    default: ""
+  snapshot_prefix:
+    type: string
+    default: "bdr-thermea"
+  snapshot_base_branch:
+    type: string
+    default: "master"
+  snapshot_android_sdk:
+    type: string
+    default: ""
+  snapshot_ios_sdk:
+    type: string
+    default: ""
+
 orbs:
   android: circleci/android@2.5.0
   flutter: circleci/flutter@2.1.0
@@ -533,6 +553,34 @@ jobs:
           working_directory: packages/luciq_flutter
           command: Escape flutter publish-monorepo-luciq
 
+  create_release_snapshot:
+    executor: flutter-executor
+    steps:
+      - advanced-checkout/shallow-checkout
+      - generate_luciq_github_app_token
+      - setup_flutter
+      - run:
+          name: Configure git for push
+          command: |
+            git config user.name "luciq-ci[bot]"
+            git config user.email "luciq-ci@luciq.ai"
+            git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/luciqai/luciq-flutter-sdk.git"
+      - run:
+          name: Create and push release snapshot
+          command: |
+            VERSION="<< pipeline.parameters.snapshot_version >>"
+            if [ -z "$VERSION" ]; then
+              echo "snapshot_version pipeline parameter is required" >&2
+              exit 1
+            fi
+            # Generation already ran via setup_flutter, so skip it in the script (-s).
+            ARGS="-s -v $VERSION -p << pipeline.parameters.snapshot_prefix >> -b << pipeline.parameters.snapshot_base_branch >>"
+            ANDROID_SDK="<< pipeline.parameters.snapshot_android_sdk >>"
+            IOS_SDK="<< pipeline.parameters.snapshot_ios_sdk >>"
+            [ -n "$ANDROID_SDK" ] && ARGS="$ARGS --android-sdk $ANDROID_SDK"
+            [ -n "$IOS_SDK" ] && ARGS="$ARGS --ios-sdk $IOS_SDK"
+            bash scripts/release-snapshot.sh $ARGS
+
   release_slack_notification:
     parameters:
       channel:
@@ -547,7 +595,13 @@ jobs:
 
 workflows:
   version: 2
+  release-snapshot:
+    when: << pipeline.parameters.run_snapshot >>
+    jobs:
+      - create_release_snapshot
+
   build-test-and-approval-deploy:
+    unless: << pipeline.parameters.run_snapshot >>
     jobs:
       - test_android
       - danger:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,34 +1,5 @@
 version: 2.1
 
-parameters:
-  # --- Task: generate a generic snapshot (scripts/snapshot.sh) ---
-  run_generate_snapshot:
-    type: boolean
-    default: false
-  snapshot_ticket:
-    type: string
-    default: ""
-
-  # --- Task: release a bdr-thermea release (scripts/release-snapshot.sh) ---
-  run_release:
-    type: boolean
-    default: false
-  release_version:
-    type: string
-    default: ""
-  release_prefix:
-    type: string
-    default: "bdr-thermea"
-  release_base_branch:
-    type: string
-    default: "master"
-  release_android_sdk:
-    type: string
-    default: ""
-  release_ios_sdk:
-    type: string
-    default: ""
-
 orbs:
   android: circleci/android@2.5.0
   flutter: circleci/flutter@2.1.0
@@ -564,6 +535,10 @@ jobs:
 
   # Task: generate a generic snapshot branch (snapshot/<version>-<ticket>).
   generate_snapshot:
+    parameters:
+      ticket:
+        type: string
+        default: "SNAPSHOT"
     executor: flutter-executor
     steps:
       - advanced-checkout/shallow-checkout
@@ -577,17 +552,27 @@ jobs:
             git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/luciqai/luciq-flutter-sdk.git"
       - run:
           name: Generate and push snapshot
-          command: |
-            TICKET="<< pipeline.parameters.snapshot_ticket >>"
-            if [ -z "$TICKET" ]; then
-              echo "snapshot_ticket pipeline parameter is required" >&2
-              exit 1
-            fi
-            # Generation already ran via setup_flutter, so skip pigeon in the script (-s).
-            bash scripts/snapshot.sh -s -t "$TICKET"
+          # Generation already ran via setup_flutter, so skip pigeon in the script (-s).
+          command: bash scripts/snapshot.sh -s -t "<< parameters.ticket >>"
 
   # Task: cut a bdr-thermea release branch (release/<prefix>-<version>).
   release_bdr_thermea:
+    parameters:
+      version:
+        type: string
+        default: ""
+      prefix:
+        type: string
+        default: "bdr-thermea"
+      base_branch:
+        type: string
+        default: "master"
+      android_sdk:
+        type: string
+        default: ""
+      ios_sdk:
+        type: string
+        default: ""
     executor: flutter-executor
     steps:
       - advanced-checkout/shallow-checkout
@@ -601,16 +586,14 @@ jobs:
             git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/luciqai/luciq-flutter-sdk.git"
       - run:
           name: Create and push release
+          # Version defaults to the version already in pubspec.yaml when left empty.
+          # Generation already ran via setup_flutter, so skip it in the script (-s).
           command: |
-            VERSION="<< pipeline.parameters.release_version >>"
-            if [ -z "$VERSION" ]; then
-              echo "release_version pipeline parameter is required" >&2
-              exit 1
-            fi
-            # Generation already ran via setup_flutter, so skip it in the script (-s).
-            ARGS="-s -v $VERSION -p << pipeline.parameters.release_prefix >> -b << pipeline.parameters.release_base_branch >>"
-            ANDROID_SDK="<< pipeline.parameters.release_android_sdk >>"
-            IOS_SDK="<< pipeline.parameters.release_ios_sdk >>"
+            ARGS="-s -p << parameters.prefix >> -b << parameters.base_branch >>"
+            VERSION="<< parameters.version >>"
+            ANDROID_SDK="<< parameters.android_sdk >>"
+            IOS_SDK="<< parameters.ios_sdk >>"
+            [ -n "$VERSION" ] && ARGS="$ARGS -v $VERSION"
             [ -n "$ANDROID_SDK" ] && ARGS="$ARGS --android-sdk $ANDROID_SDK"
             [ -n "$IOS_SDK" ] && ARGS="$ARGS --ios-sdk $IOS_SDK"
             bash scripts/release-snapshot.sh $ARGS
@@ -629,21 +612,7 @@ jobs:
 
 workflows:
   version: 2
-  generate-snapshot:
-    when: << pipeline.parameters.run_generate_snapshot >>
-    jobs:
-      - generate_snapshot
-
-  release-bdr-thermea:
-    when: << pipeline.parameters.run_release >>
-    jobs:
-      - release_bdr_thermea
-
   build-test-and-approval-deploy:
-    unless:
-      or:
-        - << pipeline.parameters.run_generate_snapshot >>
-        - << pipeline.parameters.run_release >>
     jobs:
       - test_android
       - danger:
@@ -771,6 +740,35 @@ workflows:
           requires:
             - release_luciq_flutter
           context: slack-app
+      # Manual switch: approve to generate a generic snapshot branch.
+      - hold_generate_snapshot:
+          type: approval
+          filters:
+            branches:
+              only: master
+      - generate_snapshot:
+          ticket: "SNAPSHOT"
+          requires:
+            - hold_generate_snapshot
+          filters:
+            branches:
+              only: master
+      # Manual switch: approve to cut a bdr-thermea release branch.
+      # Leave version empty to use the version already in pubspec.yaml.
+      - hold_release_bdr_thermea:
+          type: approval
+          filters:
+            branches:
+              only: master
+      - release_bdr_thermea:
+          version: ""
+          prefix: "bdr-thermea"
+          base_branch: "master"
+          requires:
+            - hold_release_bdr_thermea
+          filters:
+            branches:
+              only: master
 
   send-release-notes-to-test-channel:
     jobs:

--- a/scripts/release-snapshot.sh
+++ b/scripts/release-snapshot.sh
@@ -55,10 +55,9 @@ usage() {
   cat <<EOF
 Usage: $(basename "$0") -v VERSION [OPTIONS]
 
-Required:
-  -v, --version VERSION      Flutter package version for this release (e.g. 19.9.0)
-
 Options:
+  -v, --version VERSION      Flutter package version for this release (e.g. 19.9.0).
+                             Defaults to the version already in pubspec.yaml.
   -p, --prefix PREFIX        Branch prefix / customer (default: bdr-thermea)
                              Branch becomes release/<PREFIX>-<VERSION>
   -b, --base BRANCH          Base branch to branch from (default: current branch).
@@ -101,7 +100,12 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ -z "$VERSION" ]] && error "Version is required. Use -v/--version VERSION"
+# Fall back to the version already declared in pubspec.yaml when -v is omitted.
+if [[ -z "$VERSION" ]]; then
+  VERSION=$(grep -m1 '^version:' "$PUBSPEC" | awk '{print $2}')
+  [[ -z "$VERSION" ]] && error "No version given (-v) and none found in $PUBSPEC"
+  info "No -v given; using pubspec version: $VERSION"
+fi
 [[ -z "$ANDROID_SDK" ]] && ANDROID_SDK="$VERSION"
 [[ -z "$IOS_SDK" ]] && IOS_SDK="$VERSION"
 [[ -z "$BASE_BRANCH" ]] && BASE_BRANCH="$(git rev-parse --abbrev-ref HEAD)"

--- a/scripts/release-snapshot.sh
+++ b/scripts/release-snapshot.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+set -euo pipefail
+
+# =============================================================================
+# Luciq Flutter - Release Snapshot Generator (CI)
+# -----------------------------------------------------------------------------
+# Creates a customer release branch (e.g. release/bdr-thermea-<version>),
+# bumps the SDK version strings, carries over the customer customizations that
+# live in ArgsRegistry / luciq CLI (by branching from a base branch that
+# already contains them), regenerates and commits the generated files
+# (pigeon + mockito), then pushes the branch so it can be consumed as a git
+# dependency (snapshot) from a host app's pubspec.yaml.
+#
+# ASSUMPTIONS (adjust flags if these are wrong):
+#   * Customer-specific edits to:
+#       - packages/luciq_flutter/ios/Classes/Util/ArgsRegistry.m
+#       - packages/luciq_flutter/android/.../util/ArgsRegistry.java
+#       - packages/luciq_cli/bin/luciq.dart
+#     are already committed on the --base branch and are carried over simply by
+#     branching from it. This script does NOT invent those edits.
+#   * The new version is supplied explicitly with -v/--version.
+#   * The native SDK versions default to the package version but can be
+#     overridden per-platform with --android-sdk / --ios-sdk.
+# =============================================================================
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+FLUTTER_PKG="packages/luciq_flutter"
+PUBSPEC="$FLUTTER_PKG/pubspec.yaml"
+BUILD_GRADLE="$FLUTTER_PKG/android/build.gradle"
+PODSPEC="$FLUTTER_PKG/ios/luciq_flutter.podspec"
+GEN_GITIGNORE="$FLUTTER_PKG/.gitignore"
+REPO_URL="https://github.com/luciqai/luciq-flutter-sdk.git"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+info()    { echo -e "${CYAN}[INFO]${NC} $1"; }
+success() { echo -e "${GREEN}[OK]${NC} $1"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error()   { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+
+# Portable in-place sed (BSD/macOS vs GNU/Linux CI).
+sed_inplace() {
+  if sed --version >/dev/null 2>&1; then
+    sed -i "$@"
+  else
+    sed -i '' "$@"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Args
+# -----------------------------------------------------------------------------
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") -v VERSION [OPTIONS]
+
+Required:
+  -v, --version VERSION      Flutter package version for this release (e.g. 19.9.0)
+
+Options:
+  -p, --prefix PREFIX        Branch prefix / customer (default: bdr-thermea)
+                             Branch becomes release/<PREFIX>-<VERSION>
+  -b, --base BRANCH          Base branch to branch from (default: current branch).
+                             Should already contain the customer customizations.
+      --android-sdk VERSION  Native Android SDK version for build.gradle 'api'
+                             (default: same as --version)
+      --ios-sdk VERSION      Native iOS SDK version for podspec dependency
+                             (default: same as --version)
+  -s, --skip-gen             Skip pigeon + build_runner generation
+  -n, --no-push              Commit locally but do not push
+  -h, --help                 Show this help
+
+Examples:
+  $(basename "$0") -v 19.9.0
+  $(basename "$0") -v 19.9.0 --android-sdk 19.9.0 --ios-sdk 19.9.1
+  $(basename "$0") -v 19.9.0 -b master -p bdr-thermea
+EOF
+  exit 0
+}
+
+VERSION=""
+PREFIX="bdr-thermea"
+BASE_BRANCH=""
+ANDROID_SDK=""
+IOS_SDK=""
+SKIP_GEN=false
+NO_PUSH=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -v|--version)     VERSION="$2"; shift 2 ;;
+    -p|--prefix)      PREFIX="$2"; shift 2 ;;
+    -b|--base)        BASE_BRANCH="$2"; shift 2 ;;
+    --android-sdk)    ANDROID_SDK="$2"; shift 2 ;;
+    --ios-sdk)        IOS_SDK="$2"; shift 2 ;;
+    -s|--skip-gen)    SKIP_GEN=true; shift ;;
+    -n|--no-push)     NO_PUSH=true; shift ;;
+    -h|--help)        usage ;;
+    *)                error "Unknown option: $1. Use --help for usage." ;;
+  esac
+done
+
+[[ -z "$VERSION" ]] && error "Version is required. Use -v/--version VERSION"
+[[ -z "$ANDROID_SDK" ]] && ANDROID_SDK="$VERSION"
+[[ -z "$IOS_SDK" ]] && IOS_SDK="$VERSION"
+[[ -z "$BASE_BRANCH" ]] && BASE_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+BRANCH_NAME="release/${PREFIX}-${VERSION}"
+
+info "New version    : $VERSION"
+info "Android SDK    : $ANDROID_SDK"
+info "iOS SDK        : $IOS_SDK"
+info "Base branch    : $BASE_BRANCH"
+info "Release branch : $BRANCH_NAME"
+
+# -----------------------------------------------------------------------------
+# Step 1: Create release branch from the base branch
+# -----------------------------------------------------------------------------
+info "Fetching origin/$BASE_BRANCH..."
+git fetch origin "$BASE_BRANCH"
+
+if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME" || \
+   git ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null 2>&1; then
+  error "Branch '$BRANCH_NAME' already exists (locally or on origin). Pick a new version."
+fi
+
+info "Creating '$BRANCH_NAME' from 'origin/$BASE_BRANCH'..."
+git checkout -b "$BRANCH_NAME" "origin/$BASE_BRANCH"
+success "Branch '$BRANCH_NAME' created."
+
+# -----------------------------------------------------------------------------
+# Step 2: Bump version strings
+#   - build.gradle : version '<pkg>'  +  api 'ai.luciq.library:luciq:<android sdk>'
+#   - podspec      : s.version '<pkg>' +  s.dependency 'Luciq', '<ios sdk>'
+#   - pubspec.yaml : version: <pkg>
+# -----------------------------------------------------------------------------
+info "Bumping version in $BUILD_GRADLE..."
+sed_inplace -E "s/^version '.*'/version '${VERSION}'/" "$BUILD_GRADLE"
+sed_inplace -E "s#(ai\.luciq\.library:luciq:)[^']*#\1${ANDROID_SDK}#" "$BUILD_GRADLE"
+
+info "Bumping version in $PODSPEC..."
+sed_inplace -E "s/(s\.version[[:space:]]*=[[:space:]]*)'[^']*'/\1'${VERSION}'/" "$PODSPEC"
+sed_inplace -E "s/(s\.dependency[[:space:]]+'Luciq',[[:space:]]*)'[^']*'/\1'${IOS_SDK}'/" "$PODSPEC"
+
+info "Bumping version in $PUBSPEC..."
+sed_inplace -E "s/^version:[[:space:]]*.*/version: ${VERSION}/" "$PUBSPEC"
+
+success "Version strings updated."
+git --no-pager diff -- "$BUILD_GRADLE" "$PODSPEC" "$PUBSPEC" || true
+
+# -----------------------------------------------------------------------------
+# Step 3: Regenerate pigeon + build_runner code
+# -----------------------------------------------------------------------------
+if [[ "$SKIP_GEN" == false ]]; then
+  info "Running pigeon generation..."
+  (cd "$FLUTTER_PKG" && sh scripts/pigeon.sh)
+  success "Pigeon generation complete."
+
+  info "Running build_runner..."
+  (cd "$FLUTTER_PKG" && dart run build_runner build --delete-conflicting-outputs) \
+    || warn "build_runner reported issues, continuing..."
+  success "Code generation complete."
+else
+  warn "Skipping generation (--skip-gen)."
+fi
+
+# -----------------------------------------------------------------------------
+# Step 4: Un-ignore generated files so they ship with the snapshot
+# -----------------------------------------------------------------------------
+info "Un-ignoring generated files in $GEN_GITIGNORE..."
+for pattern in '*.mocks.dart' '*.g.dart' 'android/**/generated/' 'ios/**/Generated/'; do
+  esc=$(printf '%s' "$pattern" | sed 's/[.[\*^$]/\\&/g')
+  if grep -qE "^${esc}$" "$GEN_GITIGNORE" 2>/dev/null; then
+    sed_inplace -E "s|^${esc}\$|# &|" "$GEN_GITIGNORE"
+    success "Commented out '$pattern'"
+  fi
+done
+
+info "Force-adding generated files..."
+git add -f "$FLUTTER_PKG"/android/src/main/java/ai/luciq/flutter/generated/*.java 2>/dev/null || true
+git add -f "$FLUTTER_PKG"/ios/Classes/Generated/*.h 2>/dev/null || true
+git add -f "$FLUTTER_PKG"/ios/Classes/Generated/*.m 2>/dev/null || true
+git add -f "$FLUTTER_PKG"/lib/src/generated/*.g.dart 2>/dev/null || true
+git add -f "$FLUTTER_PKG"/test/*.mocks.dart 2>/dev/null || true
+git add -f "$FLUTTER_PKG"/test/**/*.mocks.dart 2>/dev/null || true
+success "Generated files staged."
+
+# -----------------------------------------------------------------------------
+# Step 5: Commit
+# -----------------------------------------------------------------------------
+info "Staging remaining changes..."
+git add -A
+if git diff --cached --quiet; then
+  warn "No changes to commit."
+else
+  git commit -m "Release:${PREFIX}-${VERSION}
+
+Snapshot release for ${PREFIX} based on Luciq Flutter ${VERSION}
+(Android SDK ${ANDROID_SDK}, iOS SDK ${IOS_SDK})."
+  success "Committed."
+fi
+
+# -----------------------------------------------------------------------------
+# Step 6: Push
+# -----------------------------------------------------------------------------
+if [[ "$NO_PUSH" == false ]]; then
+  info "Pushing '$BRANCH_NAME' to origin..."
+  git push -u origin "$BRANCH_NAME"
+  success "Pushed."
+else
+  warn "Skipping push (--no-push). Run: git push -u origin $BRANCH_NAME"
+fi
+
+# -----------------------------------------------------------------------------
+# Step 7: Consumer instructions
+# -----------------------------------------------------------------------------
+cat <<EOF
+
+===========================================================================
+Snapshot branch ready: ${BRANCH_NAME}
+===========================================================================
+
+Add to the host app pubspec.yaml:
+
+dependencies:
+  luciq_flutter:
+    git:
+      url: ${REPO_URL}
+      path: ${FLUTTER_PKG}
+      ref: ${BRANCH_NAME}
+
+EOF

--- a/scripts/release-snapshot.sh
+++ b/scripts/release-snapshot.sh
@@ -141,7 +141,9 @@ success "Branch '$BRANCH_NAME' created."
 # -----------------------------------------------------------------------------
 info "Bumping version in $BUILD_GRADLE..."
 sed_inplace -E "s/^version '.*'/version '${VERSION}'/" "$BUILD_GRADLE"
-sed_inplace -E "s#(ai\.luciq\.library:luciq:)[^']*#\1${ANDROID_SDK}#" "$BUILD_GRADLE"
+# Matches both the public group (ai.luciq.library:luciq) and the customer group
+# (e.g. ai.luciq.library-bdrthermea:luciq) used on customer release branches.
+sed_inplace -E "s#(ai\.luciq\.library[^:]*:luciq:)[^']*#\1${ANDROID_SDK}#" "$BUILD_GRADLE"
 
 info "Bumping version in $PODSPEC..."
 sed_inplace -E "s/(s\.version[[:space:]]*=[[:space:]]*)'[^']*'/\1'${VERSION}'/" "$PODSPEC"


### PR DESCRIPTION
## Description of the change
Adds an automated way to cut a customer release snapshot branch (e.g. `release/bdr-thermea-<version>`) and publish it for use as a git dependency.

**`scripts/release-snapshot.sh`** (new):
- Creates `release/<prefix>-<version>` from a base branch (default prefix `bdr-thermea`, default base = current branch, so ArgsRegistry / CLI customizations on that branch carry over).
- Bumps the SDK version strings:
  - `android/build.gradle` -> `version '...'` and `api 'ai.luciq.library:luciq:...'`
  - `ios/luciq_flutter.podspec` -> `s.version` and `s.dependency 'Luciq', '...'`
  - `packages/luciq_flutter/pubspec.yaml` -> `version:`
- Regenerates pigeon + build_runner code (skippable with `-s`).
- Un-ignores the generated patterns in `packages/luciq_flutter/.gitignore` and force-adds the generated Java/ObjC/Dart/mocks files so the snapshot ships them.
- Commits and pushes the branch, then prints the `pubspec.yaml` git-dependency snippet.
- Native SDK versions default to the package version, overridable via `--android-sdk` / `--ios-sdk`. Portable `sed` (GNU/Linux CI + BSD/macOS).

**`.circleci/config.yml`**:
- New pipeline parameters: `run_snapshot`, `snapshot_version`, `snapshot_prefix`, `snapshot_base_branch`, `snapshot_android_sdk`, `snapshot_ios_sdk`.
- New `create_release_snapshot` job (flutter-executor) that authenticates via the Luciq GitHub App token, sets up Flutter, and runs the script with `-s`.
- New `release-snapshot` workflow gated on `run_snapshot` (triggered via the CircleCI API); the main workflow is guarded with `unless: run_snapshot` so it does not run on snapshot triggers.

Trigger example:
```
POST /project/gh/luciqai/luciq-flutter-sdk/pipeline
{ "parameters": { "run_snapshot": true, "snapshot_version": "19.9.0" } }
```

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
> N/A

## Checklists
### Development
- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review
- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request

🤖 Generated with [Claude Code](https://claude.com/claude-code)